### PR TITLE
Add back test for layout.mustache example

### DIFF
--- a/test/examples/src/main/java/io/jstach/examples/LayoutedExample.java
+++ b/test/examples/src/main/java/io/jstach/examples/LayoutedExample.java
@@ -1,0 +1,10 @@
+package io.jstach.examples;
+
+import io.jstach.jstache.JStache;
+import io.jstach.jstache.JStacheFlags;
+import io.jstach.jstache.JStacheFlags.Flag;
+
+@JStache(path = "layouted.mustache")
+@JStacheFlags(flags = { Flag.DEBUG })
+record LayoutedExample(String title, String message) {
+}

--- a/test/examples/src/main/resources/layout.mustache
+++ b/test/examples/src/main/resources/layout.mustache
@@ -1,10 +1,10 @@
 <!doctype html>
 <html>
-    <head>
-        <meta charset="UTF-8">
-        <title>{{title}}</title>
-    </head>
-    <body>
-      {{{yield}}}
-    </body>
+	<head>
+		<meta charset="UTF-8">
+		<title>{{title}}</title>
+	</head>
+	<body>
+		{{$body}}{{/body}}
+	</body>
 </html>

--- a/test/examples/src/main/resources/layouted.mustache
+++ b/test/examples/src/main/resources/layouted.mustache
@@ -1,3 +1,3 @@
-{{#layout}}
-  {{body}}
-{{/layout}}
+{{<layout.mustache}}
+{{$body}}<span>{{message}}</span>{{/body}}
+{{/layout.mustache}}

--- a/test/examples/src/test/java/io/jstach/examples/LayoutedTest.java
+++ b/test/examples/src/test/java/io/jstach/examples/LayoutedTest.java
@@ -1,0 +1,29 @@
+package io.jstach.examples;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class LayoutedTest {
+
+	@Test
+	public void testLayout() {
+		LayoutedExample example = new LayoutedExample("stuff", "Hello World!");
+
+		var actual = LayoutedExampleRenderer.of().execute(example);
+		String expected = """
+				<!doctype html>
+				<html>
+					<head>
+						<meta charset="UTF-8">
+						<title>stuff</title>
+					</head>
+					<body>
+						<span>Hello World!</span>
+					</body>
+				</html>
+						""";
+		assertEquals(expected.replaceAll("\t", "  "), actual.replaceAll("\t", "  "));
+	}
+
+}


### PR DESCRIPTION
The templates for "layout" and "layouted" still exist but the code that drives them was removed. I think this is how it is supposed to work now, and if it isn't I can make changes I guess. I find the examples useful.