### PR TITLE
Add support for "is" field accessors for booleans

### DIFF
--- a/test/examples/src/test/java/io/jstach/examples/BeanExampleTest.java
+++ b/test/examples/src/test/java/io/jstach/examples/BeanExampleTest.java
@@ -1,0 +1,54 @@
+package io.jstach.examples;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import io.jstach.jstache.JStache;
+import io.jstach.jstache.JStacheFlags;
+import io.jstach.jstache.JStacheFlags.Flag;
+import io.jstach.jstachio.JStachio;
+
+public class BeanExampleTest {
+
+	@JStache(template = """
+			Bean {{name}} is {{#active}}active{{/active}}{{^active}}not active{{/active}}!
+			""")
+	@JStacheFlags(flags = Flag.DEBUG)
+	public static class BeanExample {
+
+		private String name;
+
+		private boolean active;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public boolean isActive() {
+			return active;
+		}
+
+		public void setActive(boolean active) {
+			this.active = active;
+		}
+
+	}
+
+	@Test
+	public void testBean() throws Exception {
+		BeanExample model = new BeanExample();
+		model.setName("Rick");
+		String actual = JStachio.render(model);
+		String expected = """
+				Bean Rick is not active!
+								""";
+		assertEquals(expected, actual);
+
+	}
+
+}


### PR DESCRIPTION
Many POJOs use the Java Beans convention of "is" as a prefix for a
field accessor.