### PR TITLE
Github Actions setup-java v3

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: mvn install
         run: mvn --batch-mode --no-transfer-progress clean install -DskipTests=true
       - name: Create Aggregate Javadoc

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,12 +17,12 @@ jobs:
       NEXUS_SNAPHOP_COM_PASSWORD: ${{ secrets.NEXUS_SNAPHOP_COM_PASSWORD }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache local Maven repository
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
       NEXUS_SNAPHOP_COM_PASSWORD: ${{ secrets.NEXUS_SNAPHOP_COM_PASSWORD }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17 
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache local Maven repository
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Reference:

https://github.com/actions/setup-java/blob/main/README.md

```
NOTE: AdoptOpenJDK got moved to Eclipse Temurin 
and won't be updated anymore. It is highly recommended 
to migrate workflows from adopt to temurin to keep receiving 
software and security updates. 
```
