### PR TITLE
Add a test for nested partials with their own context inside a child template

### DIFF
--- a/test/examples/src/main/java/io/jstach/examples/LayoutedNestedExample.java
+++ b/test/examples/src/main/java/io/jstach/examples/LayoutedNestedExample.java
@@ -1,0 +1,13 @@
+package io.jstach.examples;
+
+import io.jstach.jstache.JStache;
+import io.jstach.jstache.JStacheFlags;
+import io.jstach.jstache.JStacheFlags.Flag;
+
+@JStache(path = "layouted-nested.mustache")
+@JStacheFlags(flags = { Flag.DEBUG })
+record LayoutedNestedExample(String title, Data data) {
+}
+
+record Data(String message) {
+}

--- a/test/examples/src/main/resources/layouted-nested.mustache
+++ b/test/examples/src/main/resources/layouted-nested.mustache
@@ -1,0 +1,3 @@
+{{<layout.mustache}}
+{{$body}}{{#data}}{{<message.mustache}}{{/message.mustache}}{{/data}}{{/body}}
+{{/layout.mustache}}

--- a/test/examples/src/main/resources/message.mustache
+++ b/test/examples/src/main/resources/message.mustache
@@ -1,0 +1,1 @@
+<span>{{message}}</span>

--- a/test/examples/src/test/java/io/jstach/examples/LayoutedTest.java
+++ b/test/examples/src/test/java/io/jstach/examples/LayoutedTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import io.jstach.jstachio.JStachio;
+
 public class LayoutedTest {
 
 	@Test
@@ -11,6 +13,26 @@ public class LayoutedTest {
 		LayoutedExample example = new LayoutedExample("stuff", "Hello World!");
 
 		var actual = LayoutedExampleRenderer.of().execute(example);
+		String expected = """
+				<!doctype html>
+				<html>
+					<head>
+						<meta charset="UTF-8">
+						<title>stuff</title>
+					</head>
+					<body>
+						<span>Hello World!</span>
+					</body>
+				</html>
+						""";
+		assertEquals(expected.replaceAll("\t", "  "), actual.replaceAll("\t", "  "));
+	}
+
+	@Test
+	public void testLayoutMessage() {
+		LayoutedNestedExample example = new LayoutedNestedExample("stuff", new Data("Hello World!"));
+
+		var actual = JStachio.render(example);
 		String expected = """
 				<!doctype html>
 				<html>


### PR DESCRIPTION
There's no example like this in the spec, but I don't see why
it shouldn't work, either with `{{<message}}{{/message}}` or just
`{{>message}}` (or both). It's kind of blocking me from doing anything with re-usable fragments for things like form elements.

The compilation fails:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile (default-compile) on project jstachio-examples: Compilation failure
[ERROR] /workspaces/jstachio/test/examples/src/main/java/io/jstach/examples/LayoutedNestedExample.java:[9,1] java.lang.IllegalStateException: parent (parameter partial) is already started for this context
[ERROR]         at io.jstach.apt.TemplateCompiler._beginParentSection(TemplateCompiler.java:388)
[ERROR]         at io.jstach.apt.CompilingTokenProcessor.beginParentSection(CompilingTokenProcessor.java:33)
[ERROR]         at io.jstach.apt.CompilingTokenProcessor.beginParentSection(CompilingTokenProcessor.java:10)
```

I don't know why that exception is thrown. Probably a design constraint in the template compiler?