### PR TITLE
Introduce a new configuration option for views

### DIFF
--- a/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/WebConfig.java
+++ b/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/WebConfig.java
@@ -3,12 +3,15 @@ package io.jstach.opt.spring.example;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import io.jstach.jstachio.JStachio;
 import io.jstach.opt.spring.web.JStachioHttpMessageConverter;
+import io.jstach.opt.spring.webmvc.ViewSetupHandlerInterceptor;
 
 /**
  * Configures MVC using {@link JStachioHttpMessageConverter} to allow returning models
@@ -34,6 +37,12 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
 		converters.add(new JStachioHttpMessageConverter(jstachio));
+	}
+
+	@Bean
+	@SuppressWarnings("exports")
+	public ViewSetupHandlerInterceptor viewSetupHandlerInterceptor(ApplicationContext context) {
+		return new ViewSetupHandlerInterceptor(context);
 	}
 
 }

--- a/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/HelloController.java
+++ b/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/HelloController.java
@@ -1,4 +1,4 @@
-package io.jstach.opt.spring.example;
+package io.jstach.opt.spring.example.hello;
 
 import java.io.IOException;
 import java.io.Writer;

--- a/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/HelloModel.java
+++ b/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/HelloModel.java
@@ -1,4 +1,4 @@
-package io.jstach.opt.spring.example;
+package io.jstach.opt.spring.example.hello;
 
 import io.jstach.jstache.JStache;
 import io.jstach.opt.spring.webmvc.JStachioModelView;

--- a/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/package-info.java
+++ b/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/package-info.java
@@ -1,14 +1,12 @@
 /**
- * Spring Boot MVC application using JStachio.
+ * Spring Boot MVC components using JStachio.
  * <p>
- * Application has the following:
+ * Has the following:
  * <ul>
  * <li>{@link io.jstach.opt.spring.example.hello.HelloController Controller}</li>
  * <li>{@link io.jstach.opt.spring.example.hello.HelloModel Model}</li>
  * <li>{@link io.jstach.opt.spring.example.HelloModelView View (jstachio generated
  * renderer)}</li>
- * <li>{@link io.jstach.opt.spring.example.SpringTemplateConfig Bean configuration}</li>
- * <li>{@link io.jstach.opt.spring.example.WebConfig Web configuration}</li>
  * </ul>
  * <strong> Make sure to take note of the {@link io.jstach.opt.spring.example/ annotations
  * on this module as they define the jstachio config} needed to integrate with Spring.
@@ -18,4 +16,14 @@
  * <em>This package is only exported for documenting the Spring Example. In a real world
  * app you probably would not export a package like this. </em>
  */
-package io.jstach.opt.spring.example;
+@JStacheInterfaces(templateAnnotations = { Component.class }, //
+		templateImplements = { ViewFactory.class })
+@JStacheConfig(naming = @JStacheName(suffix = "View"))
+package io.jstach.opt.spring.example.hello;
+
+import org.springframework.stereotype.Component;
+
+import io.jstach.jstache.JStacheConfig;
+import io.jstach.jstache.JStacheInterfaces;
+import io.jstach.jstache.JStacheName;
+import io.jstach.opt.spring.webmvc.ViewFactory;

--- a/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/message/MessageConfiguration.java
+++ b/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/message/MessageConfiguration.java
@@ -1,0 +1,20 @@
+package io.jstach.opt.spring.example.message;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.jstach.opt.spring.webmvc.JStachioModelViewConfigurer;
+
+@Configuration
+public class MessageConfiguration {
+
+	@Bean
+	public JStachioModelViewConfigurer configurer() {
+		return (page, model, request) -> {
+			if (page instanceof MessagePage message) {
+				message.message = "Hello configured!";
+			}
+		};
+	}
+
+}

--- a/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/message/MessageController.java
+++ b/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/message/MessageController.java
@@ -1,0 +1,26 @@
+package io.jstach.opt.spring.example.message;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.servlet.View;
+
+import io.jstach.opt.spring.webmvc.JStachioModelView;
+
+/**
+ * Example controller that uses a View which has global state injected into it via a
+ * handler interceptor.
+ *
+ * @author dsyer
+ */
+@Controller
+public class MessageController {
+
+	/**
+	 * Here we use the global configurer to inject state into the {@link View}.
+	 */
+	@GetMapping(value = "/message")
+	public View message() {
+		return JStachioModelView.of(new MessagePage());
+	}
+
+}

--- a/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/message/MessagePage.java
+++ b/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/message/MessagePage.java
@@ -1,0 +1,15 @@
+package io.jstach.opt.spring.example.message;
+
+import io.jstach.jstache.JStache;
+
+/**
+ * Model using a configurer to add state.
+ *
+ * @author agentgt
+ */
+@JStache(path = "hello")
+public class MessagePage {
+
+	public String message;
+
+}

--- a/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/message/package-info.java
+++ b/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/message/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Spring Boot MVC components using JStachio.
+ * <p>
+ * Has the following:
+ * <ul>
+ * <li>{@link MessageController Controller}</li>
+ * <li>{@link MessageConfiguration View Configurer}</li>
+ * </ul>
+ * <strong> Make sure to take note of the {@link io.jstach.opt.spring.example/ annotations
+ * on this module as they define the jstachio config} needed to integrate with Spring.
+ * </strong> This is because much of JStachio config is <em>not runtime driven but compile
+ * time driven</em>.
+ * <p>
+ * <em>This package is only exported for documenting the Spring Example. In a real world
+ * app you probably would not export a package like this. </em>
+ */
+@JStacheInterfaces(templateAnnotations = { Component.class })
+package io.jstach.opt.spring.example.message;
+
+import org.springframework.stereotype.Component;
+
+import io.jstach.jstache.JStacheInterfaces;

--- a/opt/jstachio-spring-example/src/main/java/module-info.java
+++ b/opt/jstachio-spring-example/src/main/java/module-info.java
@@ -31,12 +31,6 @@ import io.jstach.opt.spring.webmvc.ViewFactory;
  * @author agentgt
  */
 @JStachePath(prefix = "views/", suffix = ".mustache") //
-@JStacheInterfaces(
-		templateAnnotations = {Component.class}, //
-		templateImplements = {ViewFactory.class}, //
-		modelImplements = {JStachioModelView.class}
-)
-@JStacheConfig(naming = @JStacheName(suffix="View"))
 module io.jstach.opt.spring.example {
 	requires transitive io.jstach.opt.spring;
 	requires io.jstach.opt.jmustache;
@@ -54,6 +48,15 @@ module io.jstach.opt.spring.example {
 	requires com.fasterxml.jackson.databind;
 	
 	opens io.jstach.opt.spring.example to //
+	spring.core, spring.web, spring.beans, spring.context
+	;
+
+	opens io.jstach.opt.spring.example.message to //
+	spring.core, spring.web, spring.beans, spring.context //
+	, io.jstach.jstachio, io.jstach.opt.jmustache
+	;
+
+	opens io.jstach.opt.spring.example.hello to //
 	spring.core, spring.web, spring.beans, spring.context //
 	, io.jstach.jstachio, io.jstach.opt.jmustache //
 	, com.fasterxml.jackson.databind //

--- a/opt/jstachio-spring/src/main/java/io/jstach/opt/spring/webmvc/JStachioModelViewConfigurer.java
+++ b/opt/jstachio-spring/src/main/java/io/jstach/opt/spring/webmvc/JStachioModelViewConfigurer.java
@@ -1,0 +1,21 @@
+package io.jstach.opt.spring.webmvc;
+
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * User can provide instances in the application context and they will be applied to each
+ * {@link JStachioModelView} instance before rendering.
+ */
+public interface JStachioModelViewConfigurer {
+
+	/**
+	 * @param page the current {@link io.jstach.jstache.JStache} model
+	 * @param model the current Spring MVC model
+	 * @param request the current servlet request
+	 */
+	@SuppressWarnings("exports")
+	void configure(Object page, Map<String, ?> model, HttpServletRequest request);
+
+}

--- a/opt/jstachio-spring/src/main/java/io/jstach/opt/spring/webmvc/ViewSetupHandlerInterceptor.java
+++ b/opt/jstachio-spring/src/main/java/io/jstach/opt/spring/webmvc/ViewSetupHandlerInterceptor.java
@@ -1,0 +1,64 @@
+package io.jstach.opt.spring.webmvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * A {@link HandlerInterceptor} that automatically applies all
+ * {@link JStachioModelViewConfigurer} instances to views before rendering. Also
+ * implements {@link WebMvcConfigurer} so that it registers itself when the servlet
+ * context starts.
+ */
+@SuppressWarnings("exports")
+public class ViewSetupHandlerInterceptor implements HandlerInterceptor, WebMvcConfigurer {
+
+	private final List<JStachioModelViewConfigurer> configurers = new ArrayList<>();
+
+	private final ApplicationContext context;
+
+	public ViewSetupHandlerInterceptor(ApplicationContext context) {
+		for (String name : context.getBeanNamesForType(JStachioModelViewConfigurer.class)) {
+			this.configurers.add((JStachioModelViewConfigurer) context.getBean(name));
+		}
+		this.context = context;
+	}
+
+	@Override
+	public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+			ModelAndView modelAndView) throws Exception {
+		JStachioModelView view = findView(modelAndView);
+		if (view != null) {
+			Object page = view.model();
+			for (JStachioModelViewConfigurer configurer : configurers) {
+				configurer.configure(page, modelAndView.getModel(), request);
+			}
+		}
+	}
+
+	private JStachioModelView findView(ModelAndView modelAndView) {
+		if (modelAndView != null) {
+			if (modelAndView.getView() instanceof JStachioModelView) {
+				return (JStachioModelView) modelAndView.getView();
+			}
+			if (this.context.getBean(modelAndView.getViewName()) instanceof JStachioModelView view) {
+				return view;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(this);
+	}
+
+}


### PR DESCRIPTION
I find this useful for injecting cross-cutting things into views (e.g. CSRF tokens, menu layout specs etc.). The example here is trivial but it shows the general idea. The configurer is provided with the `@JStache` model, plus the `Map` model and `HttpServletRequest` from Spring. That should cover all the things that usually get rendered in reflective template views. Something similar will be needed for WebFlux.