### PR TITLE
Output refactor

### DIFF
--- a/api/jstachio/src/main/java/io/jstach/jstachio/Appender.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/Appender.java
@@ -1,6 +1,6 @@
 package io.jstach.jstachio;
 
-import java.io.IOException;
+import io.jstach.jstachio.escapers.PlainText;
 
 /**
  * A singleton like decorator for appendables that has additional methods for dealing with
@@ -31,22 +31,25 @@ import java.io.IOException;
  * variable output please file an issue.</em> Unlike an Appendable this class is expected
  * to be reused so state should be avoided and implementations should be thread safe.
  * @author agentgt
- * @param <A> the appendable
  * @see Escaper
  */
-public sealed interface Appender permits Escaper, DefaultAppender {
+public sealed interface Appender permits Escaper {
 
 	/**
 	 * Analogous to {@link Appendable#append(CharSequence)}.
+	 * @param <A> output type
+	 * @param <E> exception type
 	 * @param a appendable to write to. Always non null.
 	 * @param s unlike appendable always non null.
-	 * @throws IOException if an error happens while writting to the appendable
+	 * @throws E if an error happens while writting to the appendable
 	 * @apiNote Implementations are required to implement this method.
 	 */
 	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence s) throws E;
 
 	/**
 	 * Analogous to {@link Appendable#append(CharSequence, int, int)}.
+	 * @param <A> output type
+	 * @param <E> exception type
 	 * @param a appendable to write to. Never null.
 	 * @param csq Unlike appendable never null.
 	 * @param start start inclusive
@@ -58,6 +61,8 @@ public sealed interface Appender permits Escaper, DefaultAppender {
 
 	/**
 	 * Appends a character to an appendable.
+	 * @param <A> output type
+	 * @param <E> exception type
 	 * @param a appendable to write to. Never null.
 	 * @param c character
 	 * @throws E if an error happens while writting to the appendable
@@ -67,239 +72,72 @@ public sealed interface Appender permits Escaper, DefaultAppender {
 
 	/**
 	 * Write a short by using {@link String#valueOf(int)}
+	 * @param <A> output type
+	 * @param <E> exception type
 	 * @param a appendable to write to. Never null.
 	 * @param s short
 	 * @throws E if an error happens while writting to the appendable
 	 */
-	default <A extends Output<E>, E extends Exception> void append(A a, short s) throws E {
-		append(a, String.valueOf(s));
-	}
+	public <A extends Output<E>, E extends Exception> void append(A a, short s) throws E;
 
 	/**
 	 * Write a int by using {@link String#valueOf(int)}.
 	 * <p>
 	 * Implementations should override if they want different behavior or able to support
 	 * appendables that can write the native type.
+	 * @param <A> output type
+	 * @param <E> exception type
 	 * @param a appendable to write to. Never null.
 	 * @param i int
 	 * @throws E if an error happens while writting to the appendable
 	 */
-	default <A extends Output<E>, E extends Exception> void append(A a, int i) throws E {
-		append(a, String.valueOf(i));
-	}
+	public <A extends Output<E>, E extends Exception> void append(A a, int i) throws E;
 
 	/**
 	 * Write a long by using {@link String#valueOf(long)}.
 	 * <p>
 	 * Implementations should override if they want different behavior or able to support
 	 * appendables that can write the native type.
+	 * @param <A> output type
+	 * @param <E> exception type
 	 * @param a appendable to write to. Never null.
 	 * @param l long
 	 * @throws E if an error happens while writting to the appendable
 	 */
-	default <A extends Output<E>, E extends Exception> void append(A a, long l) throws E {
-		append(a, String.valueOf(l));
-	}
+	public <A extends Output<E>, E extends Exception> void append(A a, long l) throws E;
 
 	/**
 	 * Write a long by using {@link String#valueOf(long)}.
 	 * <p>
 	 * Implementations should override if they want different behavior or able to support
 	 * appendables that can write the native type.
+	 * @param <A> output type
+	 * @param <E> exception type
 	 * @param a appendable to write to. Never null.
 	 * @param d double
 	 * @throws E if an error happens while writting to the appendable
 	 */
-	default <A extends Output<E>, E extends Exception> void append(A a, double d) throws E {
-		append(a, String.valueOf(d));
-	}
+	public <A extends Output<E>, E extends Exception> void append(A a, double d) throws E;
 
 	/**
 	 * Write a long by using {@link String#valueOf(long)}.
 	 * <p>
 	 * Implementations should override if they want different behavior or able to support
 	 * appendables that can write the native type.
+	 * @param <A> output type
+	 * @param <E> exception type
 	 * @param a appendable to write to. Never null.
 	 * @param b boolean
 	 * @throws E if an error happens while writting to the appendable
 	 */
-	default <A extends Output<E>, E extends Exception> void append(A a, boolean b) throws E {
-		append(a, String.valueOf(b));
-	}
-
-	// /**
-	// * Decorates an appendable with this appender such that the returned appendable will
-	// * call the this appender which will then write to the inputted appendable.
-	// * @param appendable never null.
-	// * @return Appendable never null.
-	// */
-	// default Appendable toAppendable(A appendable) {
-	// return new AppenderAppendable<>(this, appendable);
-	// }
+	public <A extends Output<E>, E extends Exception> void append(A a, boolean b) throws E;
 
 	/**
 	 * Default appender simply passes the contents unchanged to the Appendable.
 	 * @return a passthrough appender
 	 */
 	public static Appender defaultAppender() {
-		return DefaultAppender.INSTANCE;
-	}
-
-	//
-	// /**
-	// * An appender that will directly call StringBuilder methods for native types.
-	// * <p>
-	// * This is a low level utility appender for where performance matters.
-	// * @return an appender specifically for {@link StringBuilder}
-	// */
-	// public static Appender<StringBuilder> stringAppender() {
-	// return StringAppender.INSTANCE;
-	// }
-
-}
-
-/**
- * Default appender simply passes the contents unchanged to the Appendable.
- * @author agentgt
- *
- */
-enum DefaultAppender implements Appender {
-
-	/**
-	 * Singleton instance
-	 */
-	INSTANCE;
-
-	@Override
-	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence s) throws E {
-		a.append(s);
-	}
-
-	@Override
-	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence csq, int start, int end) throws E {
-		a.append(csq, start, end);
-	}
-
-	@Override
-	public <A extends Output<E>, E extends Exception> void append(A a, char c) throws E {
-		a.append(c);
+		return PlainText.provider();
 	}
 
 }
-
-/// **
-// * An appender that will directly call StringBuilder methods for native types.
-// * <p>
-// * This is a low level utility class for where performance matters.
-// *
-// * @author agentgt
-// *
-// */
-// enum StringAppender implements Appender {
-//
-// /**
-// * Singleton instance
-// */
-// INSTANCE;
-//
-// /**
-// * {@inheritDoc}
-// */
-// @Override
-// public <A extends Output<E>, E extends Exception> void append(StringBuilder a,
-/// CharSequence s) {
-// a.append(s);
-// }
-//
-// /**
-// * {@inheritDoc}
-// */
-// @Override
-// public <A extends Output<E>, E extends Exception> void append(StringBuilder a,
-/// CharSequence csq, int start, int end) {
-// a.append(csq, start, end);
-// }
-//
-// /**
-// * {@inheritDoc}
-// */
-// @Override
-// public <A extends Output<E>, E extends Exception> void append(StringBuilder a, char c)
-/// {
-// a.append(c);
-// }
-//
-// /**
-// * {@inheritDoc}
-// */
-// @Override
-// public <A extends Output<E>, E extends Exception> void append(StringBuilder a, short s)
-/// {
-// a.append(s);
-// }
-//
-// /**
-// * {@inheritDoc}
-// */
-// public <A extends Output<E>, E extends Exception> void append(StringBuilder a, int i) {
-// a.append(i);
-// }
-//
-// /**
-// * {@inheritDoc}
-// */
-// public <A extends Output<E>, E extends Exception> void append(StringBuilder a, long l)
-/// {
-// a.append(l);
-// }
-//
-// /**
-// * {@inheritDoc}
-// */
-// public <A extends Output<E>, E extends Exception> void append(StringBuilder a, double
-/// d) {
-// a.append(d);
-// }
-//
-// /**
-// * {@inheritDoc}
-// */
-// public <A extends Output<E>, E extends Exception> void append(StringBuilder a, boolean
-/// b) {
-// a.append(b);
-// }
-//
-// }
-
-// class AppenderAppendable<A extends Appendable> implements Appendable {
-//
-// private final Appender appender;
-//
-// private final A appendable;
-//
-// public AppenderAppendable(Appender<A> appender, A appendable) {
-// super();
-// this.appender = appender;
-// this.appendable = appendable;
-// }
-//
-// @Override
-// public @NonNull Appendable append(@Nullable CharSequence csq) throws @Nullable E {
-// appender.append(appendable, csq);
-// return this;
-// }
-//
-// @Override
-// public @NonNull Appendable append(@Nullable CharSequence csq, int start, int end)
-// throws E {
-// appender.append(appendable, csq, start, end);
-// return this;
-// }
-//
-// @Override
-// public @NonNull Appendable append(char c) throws E {
-// appender.append(appendable, c);
-// return this;
-// }
-//
-// }

--- a/api/jstachio/src/main/java/io/jstach/jstachio/Appender.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/Appender.java
@@ -2,9 +2,6 @@ package io.jstach.jstachio;
 
 import java.io.IOException;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-
 /**
  * A singleton like decorator for appendables that has additional methods for dealing with
  * native types used to output variables that have been formatted. This interface is
@@ -37,7 +34,7 @@ import org.eclipse.jdt.annotation.Nullable;
  * @param <A> the appendable
  * @see Escaper
  */
-public sealed interface Appender<A extends Appendable> permits Escaper, DefaultAppender, StringAppender {
+public sealed interface Appender permits Escaper, DefaultAppender {
 
 	/**
 	 * Analogous to {@link Appendable#append(CharSequence)}.
@@ -46,7 +43,7 @@ public sealed interface Appender<A extends Appendable> permits Escaper, DefaultA
 	 * @throws IOException if an error happens while writting to the appendable
 	 * @apiNote Implementations are required to implement this method.
 	 */
-	public void append(A a, CharSequence s) throws IOException;
+	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence s) throws E;
 
 	/**
 	 * Analogous to {@link Appendable#append(CharSequence, int, int)}.
@@ -54,27 +51,27 @@ public sealed interface Appender<A extends Appendable> permits Escaper, DefaultA
 	 * @param csq Unlike appendable never null.
 	 * @param start start inclusive
 	 * @param end end exclusive
-	 * @throws IOException if an error happens while writting to the appendable
+	 * @throws E if an error happens while writting to the appendable
 	 * @apiNote Implementations are required to implement this method.
 	 */
-	public void append(A a, CharSequence csq, int start, int end) throws IOException;
+	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence csq, int start, int end) throws E;
 
 	/**
 	 * Appends a character to an appendable.
 	 * @param a appendable to write to. Never null.
 	 * @param c character
-	 * @throws IOException if an error happens while writting to the appendable
+	 * @throws E if an error happens while writting to the appendable
 	 * @apiNote Implementations are required to implement this method.
 	 */
-	public void append(A a, char c) throws IOException;
+	public <A extends Output<E>, E extends Exception> void append(A a, char c) throws E;
 
 	/**
 	 * Write a short by using {@link String#valueOf(int)}
 	 * @param a appendable to write to. Never null.
 	 * @param s short
-	 * @throws IOException if an error happens while writting to the appendable
+	 * @throws E if an error happens while writting to the appendable
 	 */
-	default void append(A a, short s) throws IOException {
+	default <A extends Output<E>, E extends Exception> void append(A a, short s) throws E {
 		append(a, String.valueOf(s));
 	}
 
@@ -85,9 +82,9 @@ public sealed interface Appender<A extends Appendable> permits Escaper, DefaultA
 	 * appendables that can write the native type.
 	 * @param a appendable to write to. Never null.
 	 * @param i int
-	 * @throws IOException if an error happens while writting to the appendable
+	 * @throws E if an error happens while writting to the appendable
 	 */
-	default void append(A a, int i) throws IOException {
+	default <A extends Output<E>, E extends Exception> void append(A a, int i) throws E {
 		append(a, String.valueOf(i));
 	}
 
@@ -98,9 +95,9 @@ public sealed interface Appender<A extends Appendable> permits Escaper, DefaultA
 	 * appendables that can write the native type.
 	 * @param a appendable to write to. Never null.
 	 * @param l long
-	 * @throws IOException if an error happens while writting to the appendable
+	 * @throws E if an error happens while writting to the appendable
 	 */
-	default void append(A a, long l) throws IOException {
+	default <A extends Output<E>, E extends Exception> void append(A a, long l) throws E {
 		append(a, String.valueOf(l));
 	}
 
@@ -111,9 +108,9 @@ public sealed interface Appender<A extends Appendable> permits Escaper, DefaultA
 	 * appendables that can write the native type.
 	 * @param a appendable to write to. Never null.
 	 * @param d double
-	 * @throws IOException if an error happens while writting to the appendable
+	 * @throws E if an error happens while writting to the appendable
 	 */
-	default void append(A a, double d) throws IOException {
+	default <A extends Output<E>, E extends Exception> void append(A a, double d) throws E {
 		append(a, String.valueOf(d));
 	}
 
@@ -124,39 +121,40 @@ public sealed interface Appender<A extends Appendable> permits Escaper, DefaultA
 	 * appendables that can write the native type.
 	 * @param a appendable to write to. Never null.
 	 * @param b boolean
-	 * @throws IOException if an error happens while writting to the appendable
+	 * @throws E if an error happens while writting to the appendable
 	 */
-	default void append(A a, boolean b) throws IOException {
+	default <A extends Output<E>, E extends Exception> void append(A a, boolean b) throws E {
 		append(a, String.valueOf(b));
 	}
 
-	/**
-	 * Decorates an appendable with this appender such that the returned appendable will
-	 * call the this appender which will then write to the inputted appendable.
-	 * @param appendable never null.
-	 * @return Appendable never null.
-	 */
-	default Appendable toAppendable(A appendable) {
-		return new AppenderAppendable<>(this, appendable);
-	}
+	// /**
+	// * Decorates an appendable with this appender such that the returned appendable will
+	// * call the this appender which will then write to the inputted appendable.
+	// * @param appendable never null.
+	// * @return Appendable never null.
+	// */
+	// default Appendable toAppendable(A appendable) {
+	// return new AppenderAppendable<>(this, appendable);
+	// }
 
 	/**
 	 * Default appender simply passes the contents unchanged to the Appendable.
 	 * @return a passthrough appender
 	 */
-	public static Appender<Appendable> defaultAppender() {
+	public static Appender defaultAppender() {
 		return DefaultAppender.INSTANCE;
 	}
 
-	/**
-	 * An appender that will directly call StringBuilder methods for native types.
-	 * <p>
-	 * This is a low level utility appender for where performance matters.
-	 * @return an appender specifically for {@link StringBuilder}
-	 */
-	public static Appender<StringBuilder> stringAppender() {
-		return StringAppender.INSTANCE;
-	}
+	//
+	// /**
+	// * An appender that will directly call StringBuilder methods for native types.
+	// * <p>
+	// * This is a low level utility appender for where performance matters.
+	// * @return an appender specifically for {@link StringBuilder}
+	// */
+	// public static Appender<StringBuilder> stringAppender() {
+	// return StringAppender.INSTANCE;
+	// }
 
 }
 
@@ -165,7 +163,7 @@ public sealed interface Appender<A extends Appendable> permits Escaper, DefaultA
  * @author agentgt
  *
  */
-enum DefaultAppender implements Appender<Appendable> {
+enum DefaultAppender implements Appender {
 
 	/**
 	 * Singleton instance
@@ -173,127 +171,135 @@ enum DefaultAppender implements Appender<Appendable> {
 	INSTANCE;
 
 	@Override
-	public void append(Appendable a, CharSequence s) throws IOException {
+	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence s) throws E {
 		a.append(s);
 	}
 
 	@Override
-	public void append(Appendable a, CharSequence csq, int start, int end) throws IOException {
+	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence csq, int start, int end) throws E {
 		a.append(csq, start, end);
 	}
 
 	@Override
-	public void append(Appendable a, char c) throws IOException {
+	public <A extends Output<E>, E extends Exception> void append(A a, char c) throws E {
 		a.append(c);
 	}
 
 }
 
-/**
- * An appender that will directly call StringBuilder methods for native types.
- * <p>
- * This is a low level utility class for where performance matters.
- *
- * @author agentgt
- *
- */
-enum StringAppender implements Appender<StringBuilder> {
+/// **
+// * An appender that will directly call StringBuilder methods for native types.
+// * <p>
+// * This is a low level utility class for where performance matters.
+// *
+// * @author agentgt
+// *
+// */
+// enum StringAppender implements Appender {
+//
+// /**
+// * Singleton instance
+// */
+// INSTANCE;
+//
+// /**
+// * {@inheritDoc}
+// */
+// @Override
+// public <A extends Output<E>, E extends Exception> void append(StringBuilder a,
+/// CharSequence s) {
+// a.append(s);
+// }
+//
+// /**
+// * {@inheritDoc}
+// */
+// @Override
+// public <A extends Output<E>, E extends Exception> void append(StringBuilder a,
+/// CharSequence csq, int start, int end) {
+// a.append(csq, start, end);
+// }
+//
+// /**
+// * {@inheritDoc}
+// */
+// @Override
+// public <A extends Output<E>, E extends Exception> void append(StringBuilder a, char c)
+/// {
+// a.append(c);
+// }
+//
+// /**
+// * {@inheritDoc}
+// */
+// @Override
+// public <A extends Output<E>, E extends Exception> void append(StringBuilder a, short s)
+/// {
+// a.append(s);
+// }
+//
+// /**
+// * {@inheritDoc}
+// */
+// public <A extends Output<E>, E extends Exception> void append(StringBuilder a, int i) {
+// a.append(i);
+// }
+//
+// /**
+// * {@inheritDoc}
+// */
+// public <A extends Output<E>, E extends Exception> void append(StringBuilder a, long l)
+/// {
+// a.append(l);
+// }
+//
+// /**
+// * {@inheritDoc}
+// */
+// public <A extends Output<E>, E extends Exception> void append(StringBuilder a, double
+/// d) {
+// a.append(d);
+// }
+//
+// /**
+// * {@inheritDoc}
+// */
+// public <A extends Output<E>, E extends Exception> void append(StringBuilder a, boolean
+/// b) {
+// a.append(b);
+// }
+//
+// }
 
-	/**
-	 * Singleton instance
-	 */
-	INSTANCE;
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void append(StringBuilder a, CharSequence s) {
-		a.append(s);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void append(StringBuilder a, CharSequence csq, int start, int end) {
-		a.append(csq, start, end);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void append(StringBuilder a, char c) {
-		a.append(c);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void append(StringBuilder a, short s) {
-		a.append(s);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public void append(StringBuilder a, int i) {
-		a.append(i);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public void append(StringBuilder a, long l) {
-		a.append(l);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public void append(StringBuilder a, double d) {
-		a.append(d);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public void append(StringBuilder a, boolean b) {
-		a.append(b);
-	}
-
-}
-
-class AppenderAppendable<A extends Appendable> implements Appendable {
-
-	private final Appender<A> appender;
-
-	private final A appendable;
-
-	public AppenderAppendable(Appender<A> appender, A appendable) {
-		super();
-		this.appender = appender;
-		this.appendable = appendable;
-	}
-
-	@Override
-	public @NonNull Appendable append(@Nullable CharSequence csq) throws @Nullable IOException {
-		appender.append(appendable, csq);
-		return this;
-	}
-
-	@Override
-	public @NonNull Appendable append(@Nullable CharSequence csq, int start, int end) throws IOException {
-		appender.append(appendable, csq, start, end);
-		return this;
-	}
-
-	@Override
-	public @NonNull Appendable append(char c) throws IOException {
-		appender.append(appendable, c);
-		return this;
-	}
-
-}
+// class AppenderAppendable<A extends Appendable> implements Appendable {
+//
+// private final Appender appender;
+//
+// private final A appendable;
+//
+// public AppenderAppendable(Appender<A> appender, A appendable) {
+// super();
+// this.appender = appender;
+// this.appendable = appendable;
+// }
+//
+// @Override
+// public @NonNull Appendable append(@Nullable CharSequence csq) throws @Nullable E {
+// appender.append(appendable, csq);
+// return this;
+// }
+//
+// @Override
+// public @NonNull Appendable append(@Nullable CharSequence csq, int start, int end)
+// throws E {
+// appender.append(appendable, csq, start, end);
+// return this;
+// }
+//
+// @Override
+// public @NonNull Appendable append(char c) throws E {
+// appender.append(appendable, c);
+// return this;
+// }
+//
+// }

--- a/api/jstachio/src/main/java/io/jstach/jstachio/Appender.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/Appender.java
@@ -60,7 +60,7 @@ public sealed interface Appender permits Escaper {
 	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence csq, int start, int end) throws E;
 
 	/**
-	 * Appends a character to an appendable.
+	 * Appends a character to the output.
 	 * @param <A> output type
 	 * @param <E> exception type
 	 * @param a appendable to write to. Never null.
@@ -71,7 +71,7 @@ public sealed interface Appender permits Escaper {
 	public <A extends Output<E>, E extends Exception> void append(A a, char c) throws E;
 
 	/**
-	 * Write a short by using {@link String#valueOf(int)}
+	 * Appends a short to the output.
 	 * @param <A> output type
 	 * @param <E> exception type
 	 * @param a appendable to write to. Never null.
@@ -81,7 +81,7 @@ public sealed interface Appender permits Escaper {
 	public <A extends Output<E>, E extends Exception> void append(A a, short s) throws E;
 
 	/**
-	 * Write a int by using {@link String#valueOf(int)}.
+	 * Appends an int to the output.
 	 * <p>
 	 * Implementations should override if they want different behavior or able to support
 	 * appendables that can write the native type.
@@ -94,7 +94,7 @@ public sealed interface Appender permits Escaper {
 	public <A extends Output<E>, E extends Exception> void append(A a, int i) throws E;
 
 	/**
-	 * Write a long by using {@link String#valueOf(long)}.
+	 * Appends a long to the output.
 	 * <p>
 	 * Implementations should override if they want different behavior or able to support
 	 * appendables that can write the native type.
@@ -107,7 +107,7 @@ public sealed interface Appender permits Escaper {
 	public <A extends Output<E>, E extends Exception> void append(A a, long l) throws E;
 
 	/**
-	 * Write a long by using {@link String#valueOf(long)}.
+	 * Appends a double to the output.
 	 * <p>
 	 * Implementations should override if they want different behavior or able to support
 	 * appendables that can write the native type.
@@ -120,7 +120,7 @@ public sealed interface Appender permits Escaper {
 	public <A extends Output<E>, E extends Exception> void append(A a, double d) throws E;
 
 	/**
-	 * Write a long by using {@link String#valueOf(long)}.
+	 * Appends a boolean to the output.
 	 * <p>
 	 * Implementations should override if they want different behavior or able to support
 	 * appendables that can write the native type.

--- a/api/jstachio/src/main/java/io/jstach/jstachio/Escaper.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/Escaper.java
@@ -43,7 +43,7 @@ import io.jstach.jstache.JStacheType;
  * @see JStacheContentType
  * @author agentgt
  */
-public non-sealed interface Escaper extends Appender<Appendable>, Function<String, String> {
+public non-sealed interface Escaper extends Appender, Function<String, String> {
 
 	/**
 	 * Escapes a String by using StringBuilder and calling
@@ -59,30 +59,26 @@ public non-sealed interface Escaper extends Appender<Appendable>, Function<Strin
 	 */
 	@Override
 	default String apply(String t) throws UncheckedIOException {
-		StringBuilder sb = new StringBuilder();
-		try {
-			append(sb, t);
-		}
-		catch (IOException e) {
-			throw new UncheckedIOException(e);
-		}
-		return sb.toString();
+		var out = new Output.StringOutput(new StringBuilder());
+		append(out, t);
+		return out.toString();
 	}
 
-	/**
-	 * Escapes the characters if it needs it. {@inheritDoc}
-	 */
-	public void append(Appendable a, CharSequence s) throws IOException;
-
-	/**
-	 * Escapes the characters if it needs it. {@inheritDoc}
-	 */
-	public void append(Appendable a, CharSequence csq, int start, int end) throws IOException;
-
-	/**
-	 * Escapes the character if it needs escaping. {@inheritDoc}
-	 */
-	public void append(Appendable a, char c) throws IOException;
+	// /**
+	// * Escapes the characters if it needs it. {@inheritDoc}
+	// */
+	// public void append(Appendable a, CharSequence s) throws IOException;
+	//
+	// /**
+	// * Escapes the characters if it needs it. {@inheritDoc}
+	// */
+	// public void append(Appendable a, CharSequence csq, int start, int end) throws
+	// IOException;
+	//
+	// /**
+	// * Escapes the character if it needs escaping. {@inheritDoc}
+	// */
+	// public void append(Appendable a, char c) throws IOException;
 
 	/**
 	 * Adapts a function to an Escaper.
@@ -114,12 +110,13 @@ class FunctionEscaper implements Escaper {
 	}
 
 	@Override
-	public void append(Appendable a, CharSequence s) throws IOException {
+	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence s) throws E {
 		a.append(function.apply(s.toString()));
 	}
 
 	@Override
-	public void append(Appendable a, @Nullable CharSequence csq, int start, int end) throws IOException {
+	public <A extends Output<E>, E extends Exception> void append(A a, @Nullable CharSequence csq, int start, int end)
+			throws E {
 		if (csq == null) {
 			a.append(function.apply("null"));
 			return;
@@ -128,7 +125,7 @@ class FunctionEscaper implements Escaper {
 	}
 
 	@Override
-	public void append(Appendable a, char c) throws IOException {
+	public <A extends Output<E>, E extends Exception> void append(A a, char c) throws E {
 		append(a, String.valueOf(c));
 	}
 

--- a/api/jstachio/src/main/java/io/jstach/jstachio/Escaper.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/Escaper.java
@@ -47,11 +47,11 @@ public non-sealed interface Escaper extends Appender, Function<String, String> {
 
 	/**
 	 * Escapes a String by using StringBuilder and calling
-	 * {@link #append(Appendable, CharSequence)}.
+	 * {@link #append(Output, CharSequence)}.
 	 * <p>
-	 * This method is to make Escaper implementations compatible {@link JStacheType#STACHE
-	 * zero dependency generated code} that expects Escapers to be
-	 * {@code Function<String,String>}.
+	 * This method is to make Escaper implementations compatible with
+	 * {@link JStacheType#STACHE zero dependency generated code} that expects Escapers to
+	 * be {@code Function<String,String>}.
 	 * @param t String to ge escaped.
 	 * @return escaped content
 	 * @throws UncheckedIOException if the appender or appendable throw an
@@ -64,21 +64,70 @@ public non-sealed interface Escaper extends Appender, Function<String, String> {
 		return out.toString();
 	}
 
-	// /**
-	// * Escapes the characters if it needs it. {@inheritDoc}
-	// */
-	// public void append(Appendable a, CharSequence s) throws IOException;
-	//
-	// /**
-	// * Escapes the characters if it needs it. {@inheritDoc}
-	// */
-	// public void append(Appendable a, CharSequence csq, int start, int end) throws
-	// IOException;
-	//
-	// /**
-	// * Escapes the character if it needs escaping. {@inheritDoc}
-	// */
-	// public void append(Appendable a, char c) throws IOException;
+	/**
+	 * Escapes the characters if it needs it. {@inheritDoc}
+	 */
+	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence s) throws E;
+
+	/**
+	 * Escapes the characters if it needs it. {@inheritDoc}
+	 */
+	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence csq, int start, int end) throws E;
+
+	/**
+	 * Escapes the character if it needs escaping. {@inheritDoc}
+	 */
+	public <A extends Output<E>, E extends Exception> void append(A a, char c) throws E;
+
+	/**
+	 * Escapes the character if it needs escaping. The default implementation will
+	 * {@link String#valueOf(short)} and call {@link #append(Output, CharSequence)}.
+	 * {@inheritDoc}
+	 */
+	@Override
+	default <A extends Output<E>, E extends Exception> void append(A a, short s) throws E {
+		append(a, String.valueOf(s));
+	}
+
+	/**
+	 * Escapes the character if it needs escaping. The default implementation will
+	 * {@link String#valueOf(int)} and call {@link #append(Output, CharSequence)}.
+	 * {@inheritDoc}
+	 */
+	@Override
+	default <A extends Output<E>, E extends Exception> void append(A a, int i) throws E {
+		append(a, String.valueOf(i));
+	}
+
+	/**
+	 * Escapes the character if it needs escaping. The default implementation will
+	 * {@link String#valueOf(long)} and call {@link #append(Output, CharSequence)}.
+	 * {@inheritDoc}
+	 */
+	@Override
+	default <A extends Output<E>, E extends Exception> void append(A a, long l) throws E {
+		append(a, String.valueOf(l));
+	}
+
+	/**
+	 * Escapes the character if it needs escaping. The default implementation will
+	 * {@link String#valueOf(double)} and call {@link #append(Output, CharSequence)}.
+	 * {@inheritDoc}
+	 */
+	@Override
+	default <A extends Output<E>, E extends Exception> void append(A a, double d) throws E {
+		append(a, String.valueOf(d));
+	}
+
+	/**
+	 * Escapes the character if it needs escaping. The default implementation will
+	 * {@link String#valueOf(boolean)} and call {@link #append(Output, CharSequence)}.
+	 * {@inheritDoc}
+	 */
+	@Override
+	default <A extends Output<E>, E extends Exception> void append(A a, boolean b) throws E {
+		append(a, String.valueOf(b));
+	}
 
 	/**
 	 * Adapts a function to an Escaper.

--- a/api/jstachio/src/main/java/io/jstach/jstachio/Formatter.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/Formatter.java
@@ -1,6 +1,5 @@
 package io.jstach.jstachio;
 
-import java.io.IOException;
 import java.util.function.Function;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -46,7 +45,7 @@ public interface Formatter extends Function<@Nullable Object, String> {
 
 	/**
 	 * Formats an object by using {@link StringBuilder} and calling
-	 * {@link #format(Appender, Appendable, String, Class, Object)}.
+	 * {@link #format(Appender, Output, String, Class, Object)}.
 	 * @param t the object to be formatted. Maybe <code>null</code>.
 	 * @return the formatted results as a String.
 	 */
@@ -65,7 +64,7 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <APPENDER> the downstream appender type
+	 * @param <E> the appender exception type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
@@ -73,8 +72,9 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * @param c the object class but is not guaranteed to be accurate. If it is not known
 	 * Object.class will be used.
 	 * @param o the object which maybe null
-	 * @throws IOException if the appender or appendable throws an exception
+	 * @throws E if the appender or appendable throws an exception
 	 */
+
 	<A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, Class<?> c,
 			@Nullable Object o) throws E;
 
@@ -86,13 +86,13 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <Appender> the downstream appender type
+	 * @param <E> the appender exception type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
 	 * @param path the dotted mustache like path
 	 * @param c character
-	 * @throws IOException if the appender or appendable throws an exception
+	 * @throws E if the appender or appendable throws an exception
 	 */
 	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, char c)
 			throws E {
@@ -107,13 +107,13 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <Appender> the downstream appender type
+	 * @param <E> the appender exception type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
 	 * @param path the dotted mustache like path
 	 * @param s short
-	 * @throws IOException if the appender or appendable throws an exception
+	 * @throws E if the appender or appendable throws an exception
 	 */
 	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, short s)
 			throws E {
@@ -128,13 +128,13 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <Appender> the downstream appender type
+	 * @param <E> the appender exception type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
 	 * @param path the dotted mustache like path
 	 * @param i integer
-	 * @throws IOException if the appender or appendable throws an exception
+	 * @throws E if the appender or appendable throws an exception
 	 */
 	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, int i)
 			throws E {
@@ -149,13 +149,13 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <Appender> the downstream appender type
+	 * @param <E> the appender exception type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
 	 * @param path the dotted mustache like path
 	 * @param l long
-	 * @throws IOException if the appender or appendable throws an exception
+	 * @throws E if the appender or appendable throws an exception
 	 */
 	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, long l)
 			throws E {
@@ -170,13 +170,13 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <Appender> the downstream appender type
+	 * @param <E> the appender exception type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
 	 * @param path the dotted mustache like path
 	 * @param d double
-	 * @throws IOException if the appender or appendable throws an exception
+	 * @throws E if the appender or appendable throws an exception
 	 */
 	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, double d)
 			throws E {
@@ -191,13 +191,13 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <Appender> the downstream appender type
+	 * @param <E> the appender exception type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
 	 * @param path the dotted mustache like path
 	 * @param b boolean
-	 * @throws IOException if the appender or appendable throws an exception
+	 * @throws E if the appender or appendable throws an exception
 	 */
 	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, boolean b)
 			throws E {
@@ -212,13 +212,13 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <Appender> the downstream appender type
+	 * @param <E> the appender exception type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
 	 * @param path the dotted mustache like path
 	 * @param s String
-	 * @throws IOException if the appender or appendable throws an exception
+	 * @throws E if the appender or appendable throws an exception
 	 */
 	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, String s)
 			throws E {

--- a/api/jstachio/src/main/java/io/jstach/jstachio/Formatter.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/Formatter.java
@@ -1,7 +1,6 @@
 package io.jstach.jstachio;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.function.Function;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -53,13 +52,8 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 */
 	@Override
 	default String apply(@Nullable Object t) {
-		StringBuilder sb = new StringBuilder();
-		try {
-			format(StringAppender.INSTANCE, sb, "", Object.class, t);
-		}
-		catch (IOException e) {
-			throw new UncheckedIOException(e);
-		}
+		var sb = new Output.StringOutput(new StringBuilder());
+		format(Appender.defaultAppender(), sb, "", Object.class, t);
 		return sb.toString();
 	}
 
@@ -81,8 +75,8 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * @param o the object which maybe null
 	 * @throws IOException if the appender or appendable throws an exception
 	 */
-	<A extends Appendable, APPENDER extends Appender<A>> //
-	void format(APPENDER downstream, A a, String path, Class<?> c, @Nullable Object o) throws IOException;
+	<A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, Class<?> c,
+			@Nullable Object o) throws E;
 
 	/**
 	 * Formats the object and then sends the results to the downstream appender. The
@@ -92,7 +86,7 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <APPENDER> the downstream appender type
+	 * @param <Appender> the downstream appender type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
@@ -100,8 +94,8 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * @param c character
 	 * @throws IOException if the appender or appendable throws an exception
 	 */
-	default <A extends Appendable, APPENDER extends Appender<A>> void format(APPENDER downstream, A a, String path,
-			char c) throws IOException {
+	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, char c)
+			throws E {
 		downstream.append(a, c);
 	}
 
@@ -113,7 +107,7 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <APPENDER> the downstream appender type
+	 * @param <Appender> the downstream appender type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
@@ -121,8 +115,8 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * @param s short
 	 * @throws IOException if the appender or appendable throws an exception
 	 */
-	default <A extends Appendable, APPENDER extends Appender<A>> void format(APPENDER downstream, A a, String path,
-			short s) throws IOException {
+	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, short s)
+			throws E {
 		downstream.append(a, s);
 	}
 
@@ -134,7 +128,7 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <APPENDER> the downstream appender type
+	 * @param <Appender> the downstream appender type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
@@ -142,8 +136,8 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * @param i integer
 	 * @throws IOException if the appender or appendable throws an exception
 	 */
-	default <A extends Appendable, APPENDER extends Appender<A>> void format(APPENDER downstream, A a, String path,
-			int i) throws IOException {
+	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, int i)
+			throws E {
 		downstream.append(a, i);
 	}
 
@@ -155,7 +149,7 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <APPENDER> the downstream appender type
+	 * @param <Appender> the downstream appender type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
@@ -163,8 +157,8 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * @param l long
 	 * @throws IOException if the appender or appendable throws an exception
 	 */
-	default <A extends Appendable, APPENDER extends Appender<A>> void format(APPENDER downstream, A a, String path,
-			long l) throws IOException {
+	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, long l)
+			throws E {
 		downstream.append(a, l);
 	}
 
@@ -176,7 +170,7 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <APPENDER> the downstream appender type
+	 * @param <Appender> the downstream appender type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
@@ -184,8 +178,8 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * @param d double
 	 * @throws IOException if the appender or appendable throws an exception
 	 */
-	default <A extends Appendable, APPENDER extends Appender<A>> void format(APPENDER downstream, A a, String path,
-			double d) throws IOException {
+	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, double d)
+			throws E {
 		downstream.append(a, d);
 	}
 
@@ -197,7 +191,7 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <APPENDER> the downstream appender type
+	 * @param <Appender> the downstream appender type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
@@ -205,8 +199,8 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * @param b boolean
 	 * @throws IOException if the appender or appendable throws an exception
 	 */
-	default <A extends Appendable, APPENDER extends Appender<A>> void format(APPENDER downstream, A a, String path,
-			boolean b) throws IOException {
+	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, boolean b)
+			throws E {
 		downstream.append(a, b);
 	}
 
@@ -218,7 +212,7 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * formatter should never use it directly and simply pass it on to the downstream
 	 * appender.
 	 * @param <A> the appendable type
-	 * @param <APPENDER> the downstream appender type
+	 * @param <Appender> the downstream appender type
 	 * @param downstream the downstream appender to be used instead of the appendable
 	 * directly
 	 * @param a the appendable to be passed to the appender
@@ -226,8 +220,8 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 * @param s String
 	 * @throws IOException if the appender or appendable throws an exception
 	 */
-	default <A extends Appendable, APPENDER extends Appender<A>> void format(APPENDER downstream, A a, String path,
-			String s) throws IOException {
+	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, String s)
+			throws E {
 		format(downstream, a, path, String.class, s);
 	}
 
@@ -259,8 +253,8 @@ class ObjectFunctionFormatter implements Formatter {
 	}
 
 	@Override
-	public <A extends Appendable, APPENDER extends Appender<A>> void format(APPENDER downstream, A a, String path,
-			Class<?> c, @Nullable Object o) throws IOException {
+	public <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, Class<?> c,
+			@Nullable Object o) throws E {
 		String result = function.apply(o);
 		downstream.append(a, result);
 	}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/Output.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/Output.java
@@ -1,0 +1,163 @@
+package io.jstach.jstachio;
+
+import java.io.IOException;
+
+public interface Output<E extends Exception> {
+
+	/**
+	 * Analogous to {@link Appendable#append(CharSequence)}.
+	 * @param a appendable to write to. Always non null.
+	 * @param s unlike appendable always non null.
+	 * @throws E if an error happens while writting to the appendable
+	 * @apiNote Implementations are required to implement this method.
+	 */
+	public void append(CharSequence s) throws E;
+
+	/**
+	 * Analogous to {@link Appendable#append(CharSequence, int, int)}.
+	 * @param a appendable to write to. Never null.
+	 * @param csq Unlike appendable never null.
+	 * @param start start inclusive
+	 * @param end end exclusive
+	 * @throws E if an error happens while writting to the appendable
+	 * @apiNote Implementations are required to implement this method.
+	 */
+	public void append(CharSequence csq, int start, int end) throws E;
+
+	/**
+	 * Appends a character to an appendable.
+	 * @param a appendable to write to. Never null.
+	 * @param c character
+	 * @throws IOException if an error happens while writting to the appendable
+	 * @apiNote Implementations are required to implement this method.
+	 */
+	public void append(char c) throws E;
+
+	/**
+	 * Write a short by using {@link String#valueOf(int)}
+	 * @param a appendable to write to. Never null.
+	 * @param s short
+	 * @throws IOException if an error happens while writting to the appendable
+	 */
+	default void append(short s) throws E {
+		append(String.valueOf(s));
+	}
+
+	/**
+	 * Write a int by using {@link String#valueOf(int)}.
+	 * <p>
+	 * Implementations should override if they want different behavior or able to support
+	 * appendables that can write the native type.
+	 * @param a appendable to write to. Never null.
+	 * @param i int
+	 * @throws E if an error happens while writting to the appendable
+	 */
+	default void append(int i) throws E {
+		append(String.valueOf(i));
+	}
+
+	/**
+	 * Write a long by using {@link String#valueOf(long)}.
+	 * <p>
+	 * Implementations should override if they want different behavior or able to support
+	 * appendables that can write the native type.
+	 * @param a appendable to write to. Never null.
+	 * @param l long
+	 * @throws E if an error happens while writting to the appendable
+	 */
+	default void append(long l) throws E {
+		append(String.valueOf(l));
+	}
+
+	/**
+	 * Write a long by using {@link String#valueOf(long)}.
+	 * <p>
+	 * Implementations should override if they want different behavior or able to support
+	 * appendables that can write the native type.
+	 * @param a appendable to write to. Never null.
+	 * @param d double
+	 * @throws E if an error happens while writting to the appendable
+	 */
+	default void append(double d) throws E {
+		append(String.valueOf(d));
+	}
+
+	/**
+	 * Write a long by using {@link String#valueOf(long)}.
+	 * <p>
+	 * Implementations should override if they want different behavior or able to support
+	 * appendables that can write the native type.
+	 * @param a appendable to write to. Never null.
+	 * @param b boolean
+	 * @throws E if an error happens while writting to the appendable
+	 */
+	default void append(boolean b) throws E {
+		append(String.valueOf(b));
+	}
+
+	public static Output<IOException> of(Appendable a) {
+		return new AppendableOutput(a);
+	}
+
+	public class StringOutput implements Output<RuntimeException> {
+
+		private final StringBuilder buffer;
+
+		public StringOutput(StringBuilder buffer) {
+			super();
+			this.buffer = buffer;
+		}
+
+		@Override
+		public void append(CharSequence s) {
+			buffer.append(s);
+		}
+
+		@Override
+		public void append(CharSequence csq, int start, int end) {
+			buffer.append(csq, start, end);
+
+		}
+
+		@Override
+		public void append(char c) {
+			buffer.append(c);
+
+		}
+
+		@Override
+		public String toString() {
+			return buffer.toString();
+		}
+
+	}
+
+}
+
+class AppendableOutput implements Output<IOException> {
+
+	private final Appendable appendable;
+
+	public AppendableOutput(Appendable appendable) {
+		super();
+		this.appendable = appendable;
+	}
+
+	@Override
+	public void append(CharSequence s) throws IOException {
+		appendable.append(s);
+	}
+
+	@Override
+	public void append(CharSequence csq, int start, int end) throws IOException {
+		appendable.append(csq, start, end);
+
+	}
+
+	@Override
+	public void append(char c) throws IOException {
+		appendable.append(c);
+
+	}
+
+}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/Output.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/Output.java
@@ -1,12 +1,18 @@
 package io.jstach.jstachio;
 
+import java.io.DataOutput;
 import java.io.IOException;
 
+/**
+ * Analogous to {@link Appendable} and {@link DataOutput}.
+ *
+ * @author agentgt
+ * @param <E> the exception type that can happen on output
+ */
 public interface Output<E extends Exception> {
 
 	/**
 	 * Analogous to {@link Appendable#append(CharSequence)}.
-	 * @param a appendable to write to. Always non null.
 	 * @param s unlike appendable always non null.
 	 * @throws E if an error happens while writting to the appendable
 	 * @apiNote Implementations are required to implement this method.
@@ -15,7 +21,6 @@ public interface Output<E extends Exception> {
 
 	/**
 	 * Analogous to {@link Appendable#append(CharSequence, int, int)}.
-	 * @param a appendable to write to. Never null.
 	 * @param csq Unlike appendable never null.
 	 * @param start start inclusive
 	 * @param end end exclusive
@@ -26,18 +31,17 @@ public interface Output<E extends Exception> {
 
 	/**
 	 * Appends a character to an appendable.
-	 * @param a appendable to write to. Never null.
 	 * @param c character
-	 * @throws IOException if an error happens while writting to the appendable
+	 * @throws E if an error happens while writting to the appendable
 	 * @apiNote Implementations are required to implement this method.
 	 */
+
 	public void append(char c) throws E;
 
 	/**
 	 * Write a short by using {@link String#valueOf(int)}
-	 * @param a appendable to write to. Never null.
 	 * @param s short
-	 * @throws IOException if an error happens while writting to the appendable
+	 * @throws E if an error happens while writting to the appendable
 	 */
 	default void append(short s) throws E {
 		append(String.valueOf(s));
@@ -48,7 +52,6 @@ public interface Output<E extends Exception> {
 	 * <p>
 	 * Implementations should override if they want different behavior or able to support
 	 * appendables that can write the native type.
-	 * @param a appendable to write to. Never null.
 	 * @param i int
 	 * @throws E if an error happens while writting to the appendable
 	 */
@@ -61,7 +64,6 @@ public interface Output<E extends Exception> {
 	 * <p>
 	 * Implementations should override if they want different behavior or able to support
 	 * appendables that can write the native type.
-	 * @param a appendable to write to. Never null.
 	 * @param l long
 	 * @throws E if an error happens while writting to the appendable
 	 */
@@ -74,7 +76,6 @@ public interface Output<E extends Exception> {
 	 * <p>
 	 * Implementations should override if they want different behavior or able to support
 	 * appendables that can write the native type.
-	 * @param a appendable to write to. Never null.
 	 * @param d double
 	 * @throws E if an error happens while writting to the appendable
 	 */
@@ -87,7 +88,6 @@ public interface Output<E extends Exception> {
 	 * <p>
 	 * Implementations should override if they want different behavior or able to support
 	 * appendables that can write the native type.
-	 * @param a appendable to write to. Never null.
 	 * @param b boolean
 	 * @throws E if an error happens while writting to the appendable
 	 */
@@ -95,14 +95,38 @@ public interface Output<E extends Exception> {
 		append(String.valueOf(b));
 	}
 
+	/**
+	 * Adapts an {@link Appendable} as an {@link Output}.
+	 * @param a the appendable to be wrapped.
+	 * @return string based output
+	 */
 	public static Output<IOException> of(Appendable a) {
 		return new AppendableOutput(a);
 	}
 
+	/**
+	 * Adapts a {@link StringBuilder} as an {@link Output}.
+	 * @param a the appendable to be wrapped.
+	 * @return string based output
+	 */
+	public static StringOutput of(StringBuilder a) {
+		return new StringOutput(a);
+	}
+
+	/**
+	 * String Builder based output.
+	 *
+	 * @author agentgt
+	 *
+	 */
 	public class StringOutput implements Output<RuntimeException> {
 
 		private final StringBuilder buffer;
 
+		/**
+		 * Create using supplied StringBuilder.
+		 * @param buffer never null.
+		 */
 		public StringOutput(StringBuilder buffer) {
 			super();
 			this.buffer = buffer;
@@ -128,6 +152,39 @@ public interface Output<E extends Exception> {
 		@Override
 		public String toString() {
 			return buffer.toString();
+		}
+
+		@Override
+		public void append(boolean b) throws RuntimeException {
+			buffer.append(b);
+		}
+
+		@Override
+		public void append(double d) throws RuntimeException {
+			buffer.append(d);
+		}
+
+		@Override
+		public void append(int i) throws RuntimeException {
+			buffer.append(i);
+		}
+
+		@Override
+		public void append(long l) throws RuntimeException {
+			buffer.append(l);
+		}
+
+		@Override
+		public void append(short s) throws RuntimeException {
+			buffer.append(s);
+		}
+
+		/**
+		 * The buffer that has been wrapped.
+		 * @return the wrapped builder
+		 */
+		StringBuilder getBuffer() {
+			return buffer;
 		}
 
 	}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/escapers/HtmlEscaper.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/escapers/HtmlEscaper.java
@@ -1,8 +1,7 @@
 package io.jstach.jstachio.escapers;
 
-import java.io.IOException;
-
 import io.jstach.jstachio.Escaper;
+import io.jstach.jstachio.Output;
 
 enum HtmlEscaper implements Escaper {
 
@@ -17,13 +16,13 @@ enum HtmlEscaper implements Escaper {
 	private static final String AMP = "&amp;";
 
 	@Override
-	public void append(Appendable a, CharSequence s) throws IOException {
+	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence s) throws E {
 		s = s == null ? "null" : s;
 		append(a, s, 0, s.length());
 	}
 
 	@Override
-	public void append(Appendable a, CharSequence csq, int start, int end) throws IOException {
+	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence csq, int start, int end) throws E {
 		csq = csq == null ? "null" : csq;
 		for (int i = start; i < end; i++) {
 			char c = csq.charAt(i);
@@ -58,7 +57,7 @@ enum HtmlEscaper implements Escaper {
 	}
 
 	@Override
-	public void append(Appendable a, char c) throws IOException {
+	public <A extends Output<E>, E extends Exception> void append(A a, char c) throws E {
 		switch (c) {
 			case '&' -> {
 				a.append(AMP);

--- a/api/jstachio/src/main/java/io/jstach/jstachio/escapers/HtmlEscaper.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/escapers/HtmlEscaper.java
@@ -77,4 +77,29 @@ enum HtmlEscaper implements Escaper {
 		}
 	}
 
+	@Override
+	public <A extends Output<E>, E extends Exception> void append(A a, short s) throws E {
+		a.append(s);
+	}
+
+	@Override
+	public <A extends Output<E>, E extends Exception> void append(A a, int i) throws E {
+		a.append(i);
+	}
+
+	@Override
+	public <A extends Output<E>, E extends Exception> void append(A a, long l) throws E {
+		a.append(l);
+	}
+
+	@Override
+	public <A extends Output<E>, E extends Exception> void append(A a, double d) throws E {
+		a.append(d);
+	}
+
+	@Override
+	public <A extends Output<E>, E extends Exception> void append(A a, boolean b) throws E {
+		a.append(b);
+	}
+
 }

--- a/api/jstachio/src/main/java/io/jstach/jstachio/escapers/NoEscaper.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/escapers/NoEscaper.java
@@ -22,4 +22,29 @@ enum NoEscaper implements Escaper {
 		a.append(c);
 	}
 
+	@Override
+	public <A extends Output<E>, E extends Exception> void append(A a, short s) throws E {
+		a.append(s);
+	}
+
+	@Override
+	public <A extends Output<E>, E extends Exception> void append(A a, int i) throws E {
+		a.append(i);
+	}
+
+	@Override
+	public <A extends Output<E>, E extends Exception> void append(A a, long l) throws E {
+		a.append(l);
+	}
+
+	@Override
+	public <A extends Output<E>, E extends Exception> void append(A a, double d) throws E {
+		a.append(d);
+	}
+
+	@Override
+	public <A extends Output<E>, E extends Exception> void append(A a, boolean b) throws E {
+		a.append(b);
+	}
+
 }

--- a/api/jstachio/src/main/java/io/jstach/jstachio/escapers/NoEscaper.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/escapers/NoEscaper.java
@@ -1,25 +1,24 @@
 package io.jstach.jstachio.escapers;
 
-import java.io.IOException;
-
 import io.jstach.jstachio.Escaper;
+import io.jstach.jstachio.Output;
 
 enum NoEscaper implements Escaper {
 
 	PlainText;
 
 	@Override
-	public void append(Appendable a, CharSequence s) throws IOException {
+	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence s) throws E {
 		a.append(s);
 	}
 
 	@Override
-	public void append(Appendable a, CharSequence csq, int start, int end) throws IOException {
+	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence csq, int start, int end) throws E {
 		a.append(csq, start, end);
 	}
 
 	@Override
-	public void append(Appendable a, char c) throws IOException {
+	public <A extends Output<E>, E extends Exception> void append(A a, char c) throws E {
 		a.append(c);
 	}
 

--- a/api/jstachio/src/main/java/io/jstach/jstachio/formatters/DefaultFormatter.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/formatters/DefaultFormatter.java
@@ -1,6 +1,5 @@
 package io.jstach.jstachio.formatters;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 
@@ -10,6 +9,7 @@ import io.jstach.jstache.JStacheFormatter;
 import io.jstach.jstache.JStacheFormatterTypes;
 import io.jstach.jstachio.Appender;
 import io.jstach.jstachio.Formatter;
+import io.jstach.jstachio.Output;
 import io.jstach.jstachio.context.ContextNode;
 
 /**
@@ -27,8 +27,8 @@ public interface DefaultFormatter extends Formatter {
 	 * {@inheritDoc} Will throw an NPE if parameter o is <code>null</code>.
 	 */
 	@Override
-	default <A extends Appendable, APPENDER extends Appender<A>> void format(APPENDER downstream, A a, String path,
-			Class<?> c, @Nullable Object o) throws IOException {
+	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, Class<?> c,
+			@Nullable Object o) throws E {
 		if (o == null) {
 			throw new NullPointerException("null at: '" + path + "'");
 		}
@@ -44,8 +44,8 @@ public interface DefaultFormatter extends Formatter {
 	 * {@inheritDoc} Will throw an NPE if parameter s is <code>null</code>.
 	 */
 	@Override
-	default <A extends Appendable, APPENDER extends Appender<A>> void format(APPENDER downstream, A a, String path,
-			String s) throws IOException {
+	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, String s)
+			throws E {
 		if (s == null) {
 			throw new NullPointerException("null at: '" + path + "'");
 		}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/formatters/SpecFormatter.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/formatters/SpecFormatter.java
@@ -1,6 +1,5 @@
 package io.jstach.jstachio.formatters;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 
@@ -10,6 +9,7 @@ import io.jstach.jstache.JStacheFormatter;
 import io.jstach.jstache.JStacheFormatterTypes;
 import io.jstach.jstachio.Appender;
 import io.jstach.jstachio.Formatter;
+import io.jstach.jstachio.Output;
 import io.jstach.jstachio.context.ContextNode;
 
 /**
@@ -24,8 +24,8 @@ public interface SpecFormatter extends Formatter {
 	 * {@inheritDoc}
 	 */
 	@Override
-	default <A extends Appendable, APPENDER extends Appender<A>> void format(APPENDER downstream, A a, String path,
-			Class<?> c, @Nullable Object o) throws IOException {
+	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, Class<?> c,
+			@Nullable Object o) throws E {
 		if (o instanceof ContextNode m) {
 			downstream.append(a, m.renderString());
 		}
@@ -39,8 +39,8 @@ public interface SpecFormatter extends Formatter {
 	 * if a String is null then nothing will be rendered per the mustache spec. </strong>.
 	 */
 	@Override
-	default <A extends Appendable, APPENDER extends Appender<A>> void format(APPENDER downstream, A a, String path,
-			String s) throws IOException {
+	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, String s)
+			throws E {
 		if (s != null) {
 			downstream.append(a, s);
 		}

--- a/compiler/apt/src/main/java/io/jstach/apt/TemplateClassWriter.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/TemplateClassWriter.java
@@ -66,6 +66,8 @@ class TemplateClassWriter implements LoggingSupplier {
 
 	final String _Appendable = Appendable.class.getName();
 
+	final String _Output = "io.jstach.jstachio.Output";
+
 	TemplateClassWriter(CodeWriter compilerManager, TextFileObject templateLoader, FormatCallType formatCallType) {
 		this.codeWriter = compilerManager;
 		this.templateLoader = templateLoader;
@@ -201,7 +203,7 @@ class TemplateClassWriter implements LoggingSupplier {
 
 		String templateStringJava = CodeAppendable.stringConcat(templateString);
 
-		String _Appender = APPENDER_CLASS + "<" + _Appendable + ">";
+		String _Appender = APPENDER_CLASS;
 
 		String _Formatter = jstachio ? FORMATTER_CLASS : _F_Formatter;
 		String _Escaper = jstachio ? ESCAPER_CLASS : _F_Escaper;
@@ -371,7 +373,7 @@ class TemplateClassWriter implements LoggingSupplier {
 				+ idt + _Formatter + " formatter" + "," //
 				+ idt + _Escaper + " escaper" + ") throws java.io.IOException {");
 		if (jstachio) {
-			println("        render(model, a, formatter, escaper, templateAppender());");
+			println("        render(model, " + _Output + ".of(a), formatter, escaper, templateAppender());");
 		}
 		else {
 			println("        render(model, a, formatter, escaper);");
@@ -631,10 +633,10 @@ class TemplateClassWriter implements LoggingSupplier {
 		String className = element.getQualifiedName().toString();
 		String _Appender = APPENDER_CLASS;
 
-		String _Escaper = jstachio ? _Appender + "<? super A>" : _F_Escaper;
+		String _Escaper = jstachio ? _Appender : _F_Escaper;
 		String _Formatter = jstachio ? FORMATTER_CLASS : _F_Formatter;
 
-		String _A = "<A extends " + _Appendable + ">";
+		String _A = "<A extends " + _Output + "<E>, E extends Exception>";
 
 		println("    /**");
 		println("     * Renders the passed in model.");
@@ -654,7 +656,7 @@ class TemplateClassWriter implements LoggingSupplier {
 					+ idt + "A" + " " + variables.unescapedWriter() + "," //
 					+ idt + _Formatter + " " + variables.formatter() + "," //
 					+ idt + _Escaper + " " + variables.escaper() + "," //
-					+ idt + _Appender + "<A> " + variables.appender() + ") throws java.io.IOException {");
+					+ idt + _Appender + " " + variables.appender() + ") throws E {");
 		}
 		else {
 			println("    public static  void render(" //

--- a/compiler/apt/src/main/java/io/jstach/apt/TemplateClassWriter.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/TemplateClassWriter.java
@@ -355,6 +355,20 @@ class TemplateClassWriter implements LoggingSupplier {
 			println("");
 		}
 
+		/*
+		 * We generate the StringBuilder method for performance reasons because wrapping
+		 * exceptions seems to have a cost according to JMH
+		 */
+		if (jstachio && GeneratedMethod.execute.gen(generatedMethods)) {
+			println("    @Override");
+			println("    public StringBuilder execute(" + className + " model, StringBuilder sb) {");
+			println("        render(model, " + _Output
+					+ ".of(sb), templateFormatter(), templateEscaper(), templateAppender());");
+			println("        return sb;");
+			println("    }");
+			println("");
+		}
+
 		if (jstachio)
 			println("    @Override");
 		else {

--- a/compiler/apt/src/main/java/io/jstach/apt/internal/context/Lambda.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/internal/context/Lambda.java
@@ -117,13 +117,16 @@ public sealed interface Lambda {
 			else if (raw) {
 				throw new AnnotatedException(method, "Only String return types can be annotated with Raw");
 			}
-			else if (method.getReturnType() instanceof DeclaredType dt) {
+			else {
 				returnType = ReturnKind.MODEL;
 			}
-			else {
-				throw new UnsupportedOperationException(
-						"Currently only raw String and model Class return types are supported.");
-			}
+			// else if (method.getReturnType() instanceof DeclaredType dt) {
+			// returnType = ReturnKind.MODEL;
+			// }
+			// else {
+			// throw new UnsupportedOperationException(
+			// "Currently only raw String and model Class return types are supported.");
+			// }
 			return new Method(expression, name, method, returnType, params, template);
 		}
 	}

--- a/compiler/apt/src/main/java/io/jstach/apt/internal/context/PrimitiveRenderingContext.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/internal/context/PrimitiveRenderingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Victor Nazarov <asviraspossible@gmail.com>
+ * Copyright (c) 2023, Adam Gent
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -32,43 +32,48 @@ package io.jstach.apt.internal.context;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * @author Victor Nazarov
+ * @author agentgt
  */
-public class ContextException extends Exception {
+class PrimitiveRenderingContext implements RenderingContext {
 
-	private static final long serialVersionUID = -1496891677459676774L;
+	private final JavaExpression expression;
 
-	private ContextException(@Nullable String message, TypeException ex) {
-		super(message + ": type error: " + ex.getMessage(), ex);
+	private final RenderingContext parent;
+
+	PrimitiveRenderingContext(JavaExpression expression, RenderingContext parent) {
+		this.expression = expression;
+		this.parent = parent;
 	}
 
-	public ContextException(@Nullable String message) {
-		super(message);
+	@Override
+	public String endSectionRenderingCode() {
+		return parent.endSectionRenderingCode();
 	}
 
-	public static class TypeNotAllowedContextException extends ContextException {
-
-		private static final long serialVersionUID = 3516540102898167374L;
-
-		TypeNotAllowedContextException(@Nullable String message, TypeException ex) {
-			super(message, ex);
-
-		}
-
-		TypeNotAllowedContextException(String message) {
-			super(message);
-		}
-
+	@Override
+	public @Nullable JavaExpression get(String name) throws ContextException {
+		// TODO maybe this should use parent?
+		return null;
 	}
 
-	public static class FieldNotFoundContextException extends ContextException {
+	@Override
+	public JavaExpression currentExpression() {
+		return expression;
+	}
 
-		private static final long serialVersionUID = -4520709629488727676L;
+	@Override
+	public String beginSectionRenderingCode() {
+		return parent.beginSectionRenderingCode();
+	}
 
-		FieldNotFoundContextException(String message) {
-			super(message);
-		}
+	@Override
+	public VariableContext createEnclosedVariableContext() {
+		return parent.createEnclosedVariableContext();
+	}
 
+	@Override
+	public @Nullable RenderingContext getParent() {
+		return parent;
 	}
 
 }

--- a/test/examples/src/main/java/io/jstach/examples/formatter/MyFormatter.java
+++ b/test/examples/src/main/java/io/jstach/examples/formatter/MyFormatter.java
@@ -1,6 +1,5 @@
 package io.jstach.examples.formatter;
 
-import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
@@ -10,6 +9,7 @@ import io.jstach.jstache.JStacheFormatter;
 import io.jstach.jstache.JStacheFormatterTypes;
 import io.jstach.jstachio.Appender;
 import io.jstach.jstachio.Formatter;
+import io.jstach.jstachio.Output;
 import io.jstach.jstachio.formatters.DefaultFormatter;
 
 @JStacheFormatter
@@ -19,8 +19,8 @@ public class MyFormatter implements Formatter {
 	private static final Formatter INSTANCE = new MyFormatter();
 
 	@Override
-	public <A extends Appendable, APPENDER extends Appender<A>> void format(APPENDER downstream, A a, String path,
-			Class<?> c, @Nullable Object o) throws IOException {
+	public <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, Class<?> c,
+			@Nullable Object o) throws E {
 		if (o instanceof LocalDate ld) {
 			downstream.append(a, ld.format(DateTimeFormatter.ISO_DATE));
 			return;

--- a/test/examples/src/test/java/io/jstach/examples/LowlevelTest.java
+++ b/test/examples/src/test/java/io/jstach/examples/LowlevelTest.java
@@ -8,6 +8,7 @@ import io.jstach.jstache.JStache;
 import io.jstach.jstachio.Appender;
 import io.jstach.jstachio.Escaper;
 import io.jstach.jstachio.Formatter;
+import io.jstach.jstachio.Output.StringOutput;
 import io.jstach.jstachio.formatters.DefaultFormatter;
 
 public class LowlevelTest {
@@ -32,10 +33,11 @@ public class LowlevelTest {
 	public void testRawCall() throws Exception {
 		Natives data = new Natives("s", 0, 0, 0.0d, true);
 
-		StringBuilder unescapedWriter = new StringBuilder();
+		StringOutput unescapedWriter = new StringOutput(new StringBuilder());
+
 		Formatter formatter = DefaultFormatter.provider();
-		var escaper = Appender.stringAppender();
-		Appender<StringBuilder> appender = Appender.stringAppender();
+		var escaper = Appender.defaultAppender();
+		var appender = Appender.defaultAppender();
 
 		NativesRenderer.render(data, unescapedWriter, formatter, escaper, appender);
 
@@ -63,10 +65,11 @@ public class LowlevelTest {
 	public void testRawCallWithEscaper() throws Exception {
 		Natives data = new Natives("s", 0, 0, 0.0d, true);
 
-		StringBuilder unescapedWriter = new StringBuilder();
+		StringOutput unescapedWriter = new StringOutput(new StringBuilder());
+
 		Formatter formatter = DefaultFormatter.provider();
 		Escaper escaper = Escaper.of(s -> "escaped: " + s);
-		Appender<StringBuilder> appender = Appender.stringAppender();
+		var appender = Appender.defaultAppender();
 
 		NativesRenderer.render(data, unescapedWriter, formatter, escaper, appender);
 


### PR DESCRIPTION
For a long time I avoided an "Output" abstraction/facade but after benchmarking and seeing flaws with the current "Appender" service it is clear it is more desirable and offers very little downsides.

The new Output facade allows primitives to go directly without eager conversion as well as avoids unnecessary wrapping of IOExceptions in the case of StringBuilder.