### PR TITLE
Force release builds to use UTC tz

### DIFF
--- a/bin/rebuild.sh
+++ b/bin/rebuild.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-bin/vh set pom && mvn clean package -Ddeploy=release -DskipTests -Dmaven.javadoc.skip -Dgpg.skip $@
+# We assume the tag version has ben checkedout already
+bin/vh set pom && mvn clean package -Ddeploy=release -Duser.timezone=UTC -DskipTests -Dmaven.javadoc.skip -Dgpg.skip $@

--- a/bin/src/main/java/io/jstach/script/VersionHelper.java
+++ b/bin/src/main/java/io/jstach/script/VersionHelper.java
@@ -98,12 +98,11 @@ enum Command implements HelpSupport {
 			tag(current);
 			out.println("Setting POM to release version and updating timestamp");
 			pom(current, timestamp);
-			out.println("Ready to release. Do not forget to push tags and log into sonatype to commit release!");
+			out.println("Ready to release. Do not forget to push tags!");
 			out.println("Now manually run:");
-			out.println("mvn clean deploy -Pcentral -Ddeploy=release \\");
+			out.println("mvn clean deploy -Duser.timezone=UTC -Ddeploy=release \\");
 			out.println("&& git checkout . \\");
-			out.println("&& git push \\");
-			out.println("&& git push origin " + current.tag());
+			out.println("&& git push --follow-tags");
 		}
 	},
 	CURRENT("Prints the current version based on version.properties.") {

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <metainf-services.version>1.9</metainf-services.version>
     <m2e.jdt.annotationpath>/jstachio-eea</m2e.jdt.annotationpath>
     <project.build.outputTimestamp>1685021840</project.build.outputTimestamp>
+    <ant.tstamp.now>${project.build.outputTimestamp}</ant.tstamp.now>
     <javadoc.stylesheet/>
     <jstachio.doc.resources>../</jstachio.doc.resources>
     <deploy>snapshot</deploy>
@@ -551,6 +552,11 @@
                 </goals>
                 <configuration>
                   <rules>
+                    <requireProperty>
+                      <property>user.timezone</property>
+                      <regex>UTC</regex>
+                      <message>For reproducible builds you must pass -Duser.timezone=UTC (even if your tz is UTC)</message>
+                    </requireProperty>
                     <requireSnapshotVersion>
                       <message>No Releases Allowed!</message>
                     </requireSnapshotVersion>
@@ -587,6 +593,11 @@
                      <requireJavaVersion>
                       <version>[${jstachio.jdk.release.version}]</version>
                     </requireJavaVersion>
+                    <requireProperty>
+                      <property>user.timezone</property>
+                      <regex>UTC</regex>
+                      <message>For reproducible builds you must pass -Duser.timezone=UTC (even if your tz is UTC)</message>
+                    </requireProperty>
                     <requireReleaseDeps>
                       <message>No Snapshots Allowed!</message>
                     </requireReleaseDeps>


### PR DESCRIPTION
1.0.0 was accidentally released using America/New_York tz which is normally fine as most Maven plugins will use UTC regardless but Ant uses the system default.

Ideally this would be a maven enforcer plugin and not a property check.