### PR TITLE
Fix #157 add more aggressive html5 escaping

### DIFF
--- a/api/jstachio/src/main/java/io/jstach/jstachio/escapers/Html.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/escapers/Html.java
@@ -10,13 +10,42 @@ import io.jstach.jstachio.Escaper;
  * Provides a mustache spec based HTML escaper which is the default in normal mustache.
  * <p>
  * The escaper simply escapes:
- * <ul>
- * <li>'&quot;'</li>
- * <li>'&gt;'</li>
- * <li>'&lt;'</li>
- * <li>'&amp;'</li>
- * </ul>
- *
+ * <table border="1">
+ * <caption><strong>Escape table</strong></caption>
+ * <tr>
+ * <th>Character</th>
+ * <th>Escaped String</th>
+ * </tr>
+ * <tr>
+ * <td>'<code>&quot;</code>'</td>
+ * <td>{@value HtmlEscaper#QUOT}</td>
+ * </tr>
+ * <tr>
+ * <td>'<code>&amp;</code>'</td>
+ * <td>{@value HtmlEscaper#AMP}</td>
+ * </tr>
+ * <tr>
+ * <td>'<code>&#x27;</code>'</td>
+ * <td>{@value HtmlEscaper#APOS}</td>
+ * </tr>
+ * <tr>
+ * <td>'<code>&lt;</code>'</td>
+ * <td>{@value HtmlEscaper#LT}</td>
+ * </tr>
+ * <tr>
+ * <td>'<code>=</code>'</td>
+ * <td>{@value HtmlEscaper#EQUAL}</td>
+ * </tr>
+ * <tr>
+ * <td>'<code>&gt;</code>'</td>
+ * <td>{@value HtmlEscaper#GT}</td>
+ * </tr>
+ * <tr>
+ * <td>'<code>&#x60;</code>'</td>
+ * <td>{@value HtmlEscaper#BACK_TICK}</td>
+ * </tr>
+ * </table>
+ * <br />
  * <em>N.B. Unlike many XML escapers this escaper does not differentiate attribute and
  * element content. Furthermore Mustache unlike many other templating languages is content
  * agnostic. If more flexibile attribute escaping is needed a custom lambda could be used

--- a/api/jstachio/src/main/java/io/jstach/jstachio/escapers/HtmlEscaper.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/escapers/HtmlEscaper.java
@@ -7,13 +7,19 @@ enum HtmlEscaper implements Escaper {
 
 	Html;
 
-	private static final String QUOT = "&quot;";
+	static final String QUOT = "&quot;";
 
-	private static final String GT = "&gt;";
+	static final String AMP = "&amp;";
 
-	private static final String LT = "&lt;";
+	static final String APOS = "&#x27;";
 
-	private static final String AMP = "&amp;";
+	static final String LT = "&lt;";
+
+	static final String EQUAL = "&#x3D;";
+
+	static final String GT = "&gt;";
+
+	static final String BACK_TICK = "&#x60;";
 
 	@Override
 	public <A extends Output<E>, E extends Exception> void append(A a, CharSequence s) throws E {
@@ -27,29 +33,42 @@ enum HtmlEscaper implements Escaper {
 		for (int i = start; i < end; i++) {
 			char c = csq.charAt(i);
 			switch (c) {
-				case '&' -> {
+				case '"' -> { // 34
+					a.append(csq, start, i);
+					start = i + 1;
+					a.append(QUOT);
+				}
+				case '&' -> { // 38
 					a.append(csq, start, i);
 					start = i + 1;
 					a.append(AMP);
 
 				}
-				case '<' -> {
+				case '\'' -> { // 39
+					a.append(csq, start, i);
+					start = i + 1;
+					a.append(APOS);
+				}
+				case '<' -> { // 60
 					a.append(csq, start, i);
 					start = i + 1;
 					a.append(LT);
-
 				}
-				case '>' -> {
+				case '=' -> { // 61
+					a.append(csq, start, i);
+					start = i + 1;
+					a.append(EQUAL);
+				}
+				case '>' -> { // 62
 					a.append(csq, start, i);
 					start = i + 1;
 					a.append(GT);
 				}
-				case '"' -> {
+				case '`' -> { // 96
 					a.append(csq, start, i);
 					start = i + 1;
-					a.append(QUOT);
+					a.append(BACK_TICK);
 				}
-
 			}
 		}
 		a.append(csq, start, end);
@@ -59,17 +78,26 @@ enum HtmlEscaper implements Escaper {
 	@Override
 	public <A extends Output<E>, E extends Exception> void append(A a, char c) throws E {
 		switch (c) {
+			case '"' -> {
+				a.append(QUOT);
+			}
 			case '&' -> {
 				a.append(AMP);
+			}
+			case '\'' -> {
+				a.append(APOS);
 			}
 			case '<' -> {
 				a.append(LT);
 			}
+			case '=' -> {
+				a.append(EQUAL);
+			}
 			case '>' -> {
 				a.append(GT);
 			}
-			case '"' -> {
-				a.append(QUOT);
+			case '`' -> {
+				a.append(BACK_TICK);
 			}
 			default -> {
 				a.append(c);

--- a/test/examples/src/test/java/io/jstach/examples/htmlescaper/HtmlEscapeTest.java
+++ b/test/examples/src/test/java/io/jstach/examples/htmlescaper/HtmlEscapeTest.java
@@ -1,0 +1,33 @@
+package io.jstach.examples.htmlescaper;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import io.jstach.jstache.JStache;
+
+public class HtmlEscapeTest {
+
+	@JStache(template = """
+			<div alt="{{attr}}">
+			{{body}}
+			</div>
+			""")
+	public record EscapeModel(String attr, String body) {
+
+	}
+
+	@Test
+	public void testName() throws Exception {
+		var m = new EscapeModel("\"&\'<=>`", "\"&\'<=>`");
+		String actual = EscapeModelRenderer.of().execute(m);
+		String expected = """
+				<div alt="&quot;&amp;&#x27;&lt;&#x3D;&gt;&#x60;">
+				&quot;&amp;&#x27;&lt;&#x3D;&gt;&#x60;
+				</div>
+				""";
+
+		assertEquals(expected, actual);
+	}
+
+}

--- a/test/examples/src/test/java/io/jstach/examples/htmlescaper/package-info.java
+++ b/test/examples/src/test/java/io/jstach/examples/htmlescaper/package-info.java
@@ -1,0 +1,2 @@
+@org.eclipse.jdt.annotation.NonNullByDefault
+package io.jstach.examples.htmlescaper;

--- a/test/examples/src/test/java/io/jstach/examples/lambda/LambdaPartialTest.java
+++ b/test/examples/src/test/java/io/jstach/examples/lambda/LambdaPartialTest.java
@@ -26,7 +26,7 @@ public class LambdaPartialTest {
 		String actual = JStachio.render(m);
 		String expected = """
 				bingo
-				LambdaSectionParent[stuff=ignore]
+				LambdaSectionParent[stuff&#x3D;ignore]
 								""";
 		assertEquals(expected, actual);
 	}


### PR DESCRIPTION
The original Mustache spec and various implementations only escaped

* `"`
* `&`
* `<`
* `>`

JStachio kept with that minimum HTML version agnostic escaping expecting users to use different escaping on attributes through a lambda. 

Unfortunately that is unrealistic and dangerous and I should have added the additional following characters in:

* `\``
* `'`
* `=`

I don't think the above problem deserves a CVE as it was documented that it only did the original 4 and while these additional characters prevent some level of script injection of attributes there are probably other exploits that can be done on HTML attributes (particularly the on attributes) with script tags.

Attribute escaping (and examination of scripts in those attributes) will at some point be provided as a feature through a lambda to prevent those kinds of exploits but for now it is best to only use trusted or sanitized content for HTML attributes.