### PR TITLE
Add nullable annotation marking config #164

### DIFF
--- a/api/annotation/src/main/java/io/jstach/jstache/JStacheFlags.java
+++ b/api/annotation/src/main/java/io/jstach/jstache/JStacheFlags.java
@@ -1,13 +1,16 @@
 package io.jstach.jstache;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Compiler feature flags that are subject to change. Use at your own risk!
+ * Compiler <strong>feature flags that are subject to change. Use at your own
+ * risk!</strong>
  * <p>
  * <strong>Flags maybe added without a major version change unlike the rest of the
  * API.</strong> If a flag becomes popular enough it will eventually make its way to
@@ -142,5 +145,12 @@ public @interface JStacheFlags {
 		PRE_ENCODE_DISABLE;
 
 	}
+
+	/**
+	 * Annotation to use for marking nullable types in generated code. The annotation must
+	 * be a {@link ElementType#TYPE_USE} compatible annotation.
+	 * @return {@link Inherited} signaling unspecified.
+	 */
+	Class<? extends Annotation> nullableAnnotation() default Inherited.class;
 
 }

--- a/compiler/apt/src/main/java/io/jstach/apt/TemplateClassWriter.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/TemplateClassWriter.java
@@ -65,8 +65,6 @@ class TemplateClassWriter implements LoggingSupplier {
 
 	final String idt = "\n        ";
 
-	final String _F_Formatter = Function.class.getName() + "< /* @Nullable */ Object, String>";
-
 	final String _F_Escaper = Function.class.getName() + "<String, String>";
 
 	final String _Appendable = Appendable.class.getName();
@@ -221,6 +219,13 @@ class TemplateClassWriter implements LoggingSupplier {
 
 		String _Appender = APPENDER_CLASS;
 
+		String nullable = model.nullableAnnotation() + " ";
+
+		final String _F_Formatter = Function.class.getName() + "<" + nullable + "Object, String>";
+		String nullable_F_Formatter = nullMarkClassRef(Function.class.getName(), nullable) + "<" + nullable
+				+ "Object, String>";
+		String nullable_F_Escaper = nullMarkClassRef(_F_Escaper, nullable);
+
 		String _Formatter = jstachio ? FORMATTER_CLASS : _F_Formatter;
 		String _Escaper = jstachio ? ESCAPER_CLASS : _F_Escaper;
 
@@ -303,8 +308,8 @@ class TemplateClassWriter implements LoggingSupplier {
 		println("     * @param escaper escaper if null the static escaper will be used");
 		println("     */");
 		println("    public " + rendererClassSimpleName + "(");
-		println("        /* @Nullable */ " + _F_Formatter + " formatter,");
-		println("        /* @Nullable */ " + _F_Escaper + " escaper) {");
+		println("        " + nullable_F_Formatter + " formatter,");
+		println("        " + nullable_F_Escaper + " escaper) {");
 		println("        super();");
 		println("        this.formatter = __formatter(formatter);");
 		println("        this.escaper = __escaper(escaper);");
@@ -313,15 +318,13 @@ class TemplateClassWriter implements LoggingSupplier {
 		if (jstachio) {
 			String formatterProvideCall = formatterTypeElement.orElseThrow().getQualifiedName() + "."
 					+ formatterPrism.orElseThrow().providesMethod() + "()";
-			println("    private static " + _Formatter + " __formatter(" + "/* @Nullable */ " + _F_Formatter
-					+ " formatter) {");
+			println("    private static " + _Formatter + " __formatter(" + nullable_F_Formatter + " formatter) {");
 			println("        return " + _Formatter + ".of(formatter != null ? formatter : " + formatterProvideCall
 					+ ");");
 			println("    }");
 		}
 		else {
-			println("    private static " + _F_Formatter + " __formatter(" + "/* @Nullable */ " + _F_Formatter
-					+ " formatter) {");
+			println("    private static " + _F_Formatter + " __formatter(" + nullable_F_Formatter + " formatter) {");
 			println("        return formatter != null ? formatter : (i -> i.toString());");
 			println("    }");
 		}
@@ -329,13 +332,12 @@ class TemplateClassWriter implements LoggingSupplier {
 		if (jstachio) {
 			String contentTypeProvideCall = contentTypeElement.orElseThrow().getQualifiedName() + "."
 					+ contentTypePrism.orElseThrow().providesMethod() + "()";
-			println("    private static " + _Escaper + " __escaper(" + "/* @Nullable */ " + _F_Escaper + " escaper) {");
+			println("    private static " + _Escaper + " __escaper(" + nullable_F_Escaper + " escaper) {");
 			println("        return " + _Escaper + ".of(escaper != null ? escaper : " + contentTypeProvideCall + ");");
 			println("    }");
 		}
 		else {
-			println("    private static " + _F_Escaper + " __escaper(" + "/* @Nullable */ " + _F_Escaper
-					+ " escaper) {");
+			println("    private static " + _F_Escaper + " __escaper(" + nullable_F_Escaper + " escaper) {");
 			println("        return escaper != null ? escaper : (i -> i);");
 			println("    }");
 		}
@@ -714,6 +716,21 @@ class TemplateClassWriter implements LoggingSupplier {
 		return t;
 	}
 
+	String nullMarkClassRef(String className, String nullable) {
+		/*
+		 * This is a quick hack that will only work for general cases
+		 */
+		int idx = className.lastIndexOf(".");
+		if (idx > 0) {
+			String pkg = className.substring(0, idx + 1);
+			String cname = className.substring(idx + 1);
+			return pkg + nullable + cname;
+		}
+		else {
+			return nullable + className;
+		}
+	}
+
 	private void writeRendererDefinitionMethod(TemplateCompilerType templateCompilerType, RendererModel model)
 			throws IOException, ProcessingException, AnnotatedException {
 
@@ -727,6 +744,8 @@ class TemplateClassWriter implements LoggingSupplier {
 		String className = element.getQualifiedName().toString();
 		String _Appender = APPENDER_CLASS;
 
+		String nullable = model.nullableAnnotation() + " ";
+		final String _F_Formatter = Function.class.getName() + "<" + nullable + "Object, String>";
 		String _Escaper = jstachio ? _Appender : _F_Escaper;
 		String _Formatter = jstachio ? FORMATTER_CLASS : _F_Formatter;
 

--- a/test/examples/src/main/java/io/jstach/examples/nullable/NullCheckAlwaysModel.java
+++ b/test/examples/src/main/java/io/jstach/examples/nullable/NullCheckAlwaysModel.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.eclipse.jdt.annotation.Nullable;
 
 import io.jstach.jstache.JStache;
+import io.jstach.jstache.JStacheFlags;
 
 @JStache(template = """
 		{{#names}}
@@ -21,6 +22,7 @@ import io.jstach.jstache.JStache;
 		---------
 		{{/names}}
 		""")
+@JStacheFlags(flags = {}, nullableAnnotation = Nullable.class)
 public record NullCheckAlwaysModel(List<@Nullable String> names) {
 
 }


### PR DESCRIPTION
There are some nasty hacks and assumptions on nullable annotation classes. Like we assume the annotations are not in the default package.