### PR TITLE
Tone down moan about jsr305

### DIFF
--- a/opt/jstachio-spring-webflux/pom.xml
+++ b/opt/jstachio-spring-webflux/pom.xml
@@ -27,12 +27,7 @@
     </dependency>
     
     <!-- 
-    The following is because project reactor does not use proper nullable annotations
-    which triggers the infamous both on javadoc and compile:
-    
-    [WARNING] warning: unknown enum constant When.MAYBE
-    
-    Please do not use this garbage. It pains me to even reference it.
+    Optional dependency because project reactor and others use jsr305 to support IDE users.
     -->
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/opt/jstachio-spring-webmvc/pom.xml
+++ b/opt/jstachio-spring-webmvc/pom.xml
@@ -23,12 +23,7 @@
       <scope>provided</scope>
     </dependency>
     <!-- 
-    The following is because project reactor and others do not use proper nullable annotations
-    which triggers the infamous both on javadoc and compile:
-    
-    [WARNING] warning: unknown enum constant When.MAYBE
-    
-    Please do not use this garbage. It pains me to even reference it.
+    Optional dependency because project reactor and others use jsr305 to support IDE users.
     -->
     <dependency>
       <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
It's not really fair to be mean to projectreactor here - they only do it to support IDE users and it's only a warning from the JDK. Complain to the IDE vendors if you want a better target? Or to the JDK maintainers (since apparently there is no nullability library that works for everyone)?

Ref: https://github.com/reactor/reactor-core/issues/903