### PR TITLE
Fix for #172 to set content type for views and #175 content length

### DIFF
--- a/opt/jstachio-spring-example/readme.md
+++ b/opt/jstachio-spring-example/readme.md
@@ -5,3 +5,8 @@ mvn spring-boot:run
 ```
 
 If jstachio is used in production make sure to set `jstachio.jmustache.disable=true`.
+
+
+Because of modularization the tests are blackbox tests and are in:
+
+`test/jstachio-test-spring-example`

--- a/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/WebConfig.java
+++ b/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/WebConfig.java
@@ -38,7 +38,7 @@ public class WebConfig implements WebMvcConfigurer {
 
 	@Override
 	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
-		converters.add(new JStachioHttpMessageConverter(jstachio));
+		converters.add(0, new JStachioHttpMessageConverter(jstachio));
 	}
 
 	/**

--- a/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/HelloController.java
+++ b/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/HelloController.java
@@ -95,6 +95,7 @@ public class HelloController {
 	 * @return the model that will be used as View
 	 * @see JStachioHttpMessageConverter
 	 */
+	@SuppressWarnings("exports")
 	@GetMapping(value = "/mvc")
 	public View mvc() {
 		return new HelloModel("Spring Boot MVC is now JStachioed!");

--- a/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/HelloController.java
+++ b/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/HelloController.java
@@ -16,6 +16,7 @@ import io.jstach.jstache.JStacheInterfaces;
 import io.jstach.jstachio.Template;
 import io.jstach.jstachio.TemplateModel;
 import io.jstach.opt.spring.web.JStachioHttpMessageConverter;
+import io.jstach.opt.spring.webmvc.JStachioModelView;
 
 /**
  * Example hello world controller using different ways to use JStachio for web
@@ -83,22 +84,24 @@ public class HelloController {
 	}
 
 	/**
-	 * Here we use {@link JStacheInterfaces} to make our model implement a Spring View to
-	 * support the traditional servlet MVC approach. The model will use the static
-	 * jstachio singleton that will be the spring one.
+	 * Here we could use {@link JStacheInterfaces} to make our model implement
+	 * {@link JStachioModelView} to support the traditional servlet MVC approach. The
+	 * model will use the static jstachio singleton that will be the spring one.
 	 * <p>
 	 * This approach has pros and cons. It makes your models slightly coupled to Spring
 	 * MVC but allows you to return different views if say you had to redirect on some
 	 * inputs ({@link org.springframework.web.servlet.view.RedirectView}).
 	 *
 	 * @apiNote Notice that the return type is {@link View}.
-	 * @return the model that will be used as View
+	 * @return the model and view that will be used as View (see
+	 * {@link HelloModelAndView}).
 	 * @see JStachioHttpMessageConverter
+	 * @see HelloModelAndView
 	 */
 	@SuppressWarnings("exports")
 	@GetMapping(value = "/mvc")
 	public View mvc() {
-		return new HelloModel("Spring Boot MVC is now JStachioed!");
+		return new HelloModelAndView("Spring Boot MVC is now JStachioed!");
 	}
 
 	/**

--- a/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/HelloModel.java
+++ b/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/HelloModel.java
@@ -1,7 +1,6 @@
 package io.jstach.opt.spring.example.hello;
 
 import io.jstach.jstache.JStache;
-import io.jstach.opt.spring.webmvc.JStachioModelView;
 
 /**
  * Model using a resource template that is in src/main/resources/views. The path will be
@@ -10,6 +9,6 @@ import io.jstach.opt.spring.webmvc.JStachioModelView;
  * @param message The greeting message
  */
 @JStache(path = "hello")
-public record HelloModel(String message) implements JStachioModelView {
+public record HelloModel(String message) {
 
 }

--- a/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/HelloModelAndView.java
+++ b/opt/jstachio-spring-example/src/main/java/io/jstach/opt/spring/example/hello/HelloModelAndView.java
@@ -1,0 +1,21 @@
+package io.jstach.opt.spring.example.hello;
+
+import org.springframework.web.servlet.View;
+
+import io.jstach.jstache.JStache;
+import io.jstach.opt.spring.webmvc.JStachioModelView;
+
+/**
+ * Model that implements {@link JStachioModelView} using a resource template that is in
+ * src/main/resources/views. The path will be expanded via the
+ * {@link io.jstach.jstache.JStacheConfig} on the projects module.
+ * <p>
+ * Because this model implements a Spring {@link View} you can return it directly from a
+ * controller.
+ * @author agentgt
+ * @param message The greeting message
+ */
+@JStache(path = "hello")
+public record HelloModelAndView(String message) implements JStachioModelView {
+
+}

--- a/opt/jstachio-spring-example/src/main/java/module-info.java
+++ b/opt/jstachio-spring-example/src/main/java/module-info.java
@@ -23,6 +23,7 @@ import io.jstach.jstache.JStachePath;
  * <a href="https://github.com/jstachio/jstachio/tree/main/opt/jstachio-spring-example">directly on github.</a> 
  * </em>
  * 
+ * @apiNote This module is not public API as it is just an example and thus does not follow semver policy!
  * @author agentgt
  */
 @JStachePath(prefix = "views/", suffix = ".mustache") //

--- a/opt/jstachio-spring-webflux-example/src/main/java/module-info.java
+++ b/opt/jstachio-spring-webflux-example/src/main/java/module-info.java
@@ -21,6 +21,7 @@
  * <a href="https://github.com/jstachio/jstachio/tree/main/opt/jstachio-spring-webflux-example">directly on github.</a> 
  * </em>
  * 
+ * @apiNote This module is not public API as it is just an example and thus does not follow semver policy!
  * @author agentgt
  */
 module io.jstach.opt.spring.webflux.example {

--- a/opt/jstachio-spring-webmvc/src/main/java/io/jstach/opt/spring/webmvc/ByteCountOutput.java
+++ b/opt/jstachio-spring-webmvc/src/main/java/io/jstach/opt/spring/webmvc/ByteCountOutput.java
@@ -1,0 +1,68 @@
+package io.jstach.opt.spring.webmvc;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+
+import io.jstach.jstachio.Output;
+
+/*
+ * TODO incorporate this with Output.of
+ */
+class ByteCountOutput implements Output.EncodedOutput<IOException> {
+
+	private final OutputStream outputStream;
+
+	private final Charset charset;
+
+	private long size = 0;
+
+	public ByteCountOutput(OutputStream outputStream, Charset charset) {
+		super();
+		this.outputStream = outputStream;
+		this.charset = charset;
+	}
+
+	@Override
+	public void write(byte[] b) throws IOException {
+		size += b.length;
+		outputStream.write(b);
+	}
+
+	@Override
+	public void write(byte[] bytes, int off, int len) throws IOException {
+		size += len;
+		outputStream.write(bytes, off, len);
+	}
+
+	@Override
+	public void append(char c) throws IOException {
+		var bytes = ("" + c).getBytes(this.charset);
+		size += bytes.length;
+		outputStream.write(bytes);
+	}
+
+	@Override
+	public void append(CharSequence csq) throws IOException {
+		var bytes = csq.toString().getBytes(this.charset);
+		size += bytes.length;
+		outputStream.write(bytes);
+	}
+
+	@Override
+	public void append(CharSequence csq, int start, int end) throws IOException {
+		var bytes = csq.subSequence(start, end).toString().getBytes(this.charset);
+		size += bytes.length;
+		outputStream.write(bytes);
+	}
+
+	@Override
+	public Charset charset() {
+		return charset;
+	}
+
+	public long size() {
+		return size;
+	}
+
+}

--- a/opt/jstachio-spring-webmvc/src/main/java/io/jstach/opt/spring/webmvc/JStachioModelView.java
+++ b/opt/jstachio-spring-webmvc/src/main/java/io/jstach/opt/spring/webmvc/JStachioModelView.java
@@ -11,7 +11,6 @@ import org.springframework.web.servlet.view.RedirectView;
 import io.jstach.jstache.JStache;
 import io.jstach.jstache.JStacheInterfaces;
 import io.jstach.jstachio.JStachio;
-import io.jstach.jstachio.Output;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -49,7 +48,11 @@ public interface JStachioModelView extends View {
 			charset = StandardCharsets.UTF_8;
 		}
 		try (var o = response.getOutputStream()) {
-			jstachio().write(model(), Output.of(o, charset));
+			var bo = jstachio().write(model(), new ByteCountOutput(o, charset));
+			long length = bo.size();
+			if (length < Integer.MAX_VALUE) {
+				response.setContentLength((int) bo.size());
+			}
 		}
 
 	}

--- a/opt/jstachio-spring-webmvc/src/main/java/module-info.java
+++ b/opt/jstachio-spring-webmvc/src/main/java/module-info.java
@@ -44,6 +44,7 @@ module io.jstach.opt.spring.webmvc {
 	/*
 	 * start required for Spring webmvc support
 	 */
+	requires spring.web;
 	requires spring.webmvc;
 	requires static jakarta.servlet;
 	/* end spring mvc optional deps*/

--- a/opt/jstachio-spring-webmvc/src/main/java/module-info.java
+++ b/opt/jstachio-spring-webmvc/src/main/java/module-info.java
@@ -46,6 +46,9 @@ module io.jstach.opt.spring.webmvc {
 	 */
 	requires spring.web;
 	requires spring.webmvc;
+	requires spring.beans;
+	requires spring.core;
+	requires spring.context;
 	requires static jakarta.servlet;
 	/* end spring mvc optional deps*/
 	

--- a/opt/jstachio-spring/src/main/java/io/jstach/opt/spring/web/JStachioHttpMessageConverter.java
+++ b/opt/jstachio-spring/src/main/java/io/jstach/opt/spring/web/JStachioHttpMessageConverter.java
@@ -67,7 +67,13 @@ public class JStachioHttpMessageConverter extends AbstractHttpMessageConverter<O
 	@Override
 	protected void writeInternal(Object t, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException {
-		jstachio.write(t, Output.of(outputMessage.getBody(), getDefaultCharset()));
+		/*
+		 * Its unclear if the body needs to be closed. Springs Jackson support seems to
+		 * want to avoid closing so we will do the same.
+		 */
+		var body = outputMessage.getBody();
+		jstachio.write(t, Output.of(body, getDefaultCharset()));
+		body.flush();
 	}
 
 }

--- a/opt/pom.xml
+++ b/opt/pom.xml
@@ -16,7 +16,6 @@
     <module>jstachio-spring-webflux</module>
   </modules>
   <properties>
-    <spring-boot.version>3.1.0</spring-boot.version>
     <parent.root>${basedir}/../..</parent.root>
   </properties>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,8 @@
     <jstachio.tag>&lt;div class="jstachio-version"&gt; ${jstachio.doc.message} &lt;br/&gt; ${jstachio.doc.ahref}&lt;/div&gt;</jstachio.tag>
     
     <spring.version>6.0.9</spring.version>
-    
+    <spring-boot.version>3.1.0</spring-boot.version>
+
   </properties>
   <modules>
     <module>etc</module>

--- a/test/jstachio-test-spring-example/pom.xml
+++ b/test/jstachio-test-spring-example/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.jstach</groupId>
+    <artifactId>jstachio-test-parent</artifactId>
+    <version>1.2.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>jstachio-test-spring-example</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>jstachio-spring-example</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/test/jstachio-test-spring-example/src/test/java/io/jstach/test/opt/spring/example/HelloControllerTest.java
+++ b/test/jstachio-test-spring-example/src/test/java/io/jstach/test/opt/spring/example/HelloControllerTest.java
@@ -1,0 +1,140 @@
+package io.jstach.test.opt.spring.example;
+
+import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import io.jstach.opt.spring.example.App;
+import io.jstach.opt.spring.example.SpringTemplateConfig;
+import io.jstach.opt.spring.example.WebConfig;
+
+@SpringBootTest(classes = { App.class, WebConfig.class, SpringTemplateConfig.class })
+@AutoConfigureMockMvc
+public class HelloControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	static final String SLASH_BODY = """
+			<!doctype html>
+			<html lang="en">
+			  <head>
+			    <meta charset="utf-8">
+			    <meta name="viewport" content="width=device-width, initial-scale=1">
+			    <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css">
+			    <title>Hello, Spring Boot is now JStachioed!!</title>
+			  </head>
+			  <body>
+			    <main class="container">
+			      <h1>Spring Boot is now JStachioed!</h1>
+			    </main>
+			  </body>
+			</html>""";
+
+	@Test
+	public void testHelloWithMediaTypeAll() throws Exception {
+		var rb = MockMvcRequestBuilders.get("/").accept(MediaType.ALL);
+		var result = mockMvc.perform(rb).andReturn();
+		var bytes = result.getResponse().getContentAsByteArray();
+		System.out.println(bytes.length);
+		String body = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+		assertEquals(414, result.getResponse().getContentLength());
+		assertEquals(414, SLASH_BODY.getBytes(StandardCharsets.UTF_8).length);
+		assertEquals(414, body.getBytes(StandardCharsets.UTF_8).length);
+		assertEquals(SLASH_BODY, body);
+		String contentType = result.getResponse().getContentType();
+		assertEquals("text/html;charset=UTF-8", contentType);
+	}
+
+	@Test
+	public void testTemplateModelWithAcceptJson() throws Exception {
+		var rb = MockMvcRequestBuilders.get("/templateModel").accept(MediaType.APPLICATION_JSON);
+		var result = mockMvc.perform(rb).andReturn();
+		String expectedBody = """
+				<!doctype html>
+				<html lang="en">
+				  <head>
+				    <meta charset="utf-8">
+				    <meta name="viewport" content="width=device-width, initial-scale=1">
+				    <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css">
+				    <title>Hello, Spring Boot is using JStachio TemplateModel!!</title>
+				  </head>
+				  <body>
+				    <main class="container">
+				      <h1>Spring Boot is using JStachio TemplateModel!</h1>
+				    </main>
+				  </body>
+				</html>""";
+		assertResponse(result.getResponse(), expectedBody);
+	}
+
+	@Test
+	public void testResponseEntity() throws Exception {
+		var rb = MockMvcRequestBuilders.get("/responseEntity");
+		var result = mockMvc.perform(rb).andReturn();
+		String expectedBody = """
+				<!doctype html>
+				<html lang="en">
+				  <head>
+				    <meta charset="utf-8">
+				    <meta name="viewport" content="width=device-width, initial-scale=1">
+				    <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css">
+				    <title>Hello, Spring Boot is using JStachio ResponseEntity. This is a 400 http error code but is not an actual error!!</title>
+				  </head>
+				  <body>
+				    <main class="container">
+				      <h1>Spring Boot is using JStachio ResponseEntity. This is a 400 http error code but is not an actual error!</h1>
+				    </main>
+				  </body>
+				</html>""";
+
+		assertResponse(result.getResponse(), expectedBody);
+		assertEquals(400, result.getResponse().getStatus());
+	}
+
+	@Test
+	public void testMvc() throws Exception {
+		var rb = MockMvcRequestBuilders.get("/mvc");
+		var result = mockMvc.perform(rb).andReturn();
+		String expectedBody = """
+				<!doctype html>
+				<html lang="en">
+				  <head>
+				    <meta charset="utf-8">
+				    <meta name="viewport" content="width=device-width, initial-scale=1">
+				    <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css">
+				    <title>Hello, Spring Boot MVC is now JStachioed!!</title>
+				  </head>
+				  <body>
+				    <main class="container">
+				      <h1>Spring Boot MVC is now JStachioed!</h1>
+				    </main>
+				  </body>
+				</html>""";
+
+		assertResponse(result.getResponse(), expectedBody);
+	}
+
+	private void assertResponse(MockHttpServletResponse response, String expectedBody)
+			throws UnsupportedEncodingException {
+		String body = response.getContentAsString(StandardCharsets.UTF_8);
+		assertEquals(expectedBody, body);
+		int expectedLength = expectedBody.getBytes(StandardCharsets.UTF_8).length;
+		assertEquals(expectedLength, response.getContentLength());
+		assertEquals(expectedLength, body.getBytes(StandardCharsets.UTF_8).length);
+		String contentType = response.getContentType();
+		assertEquals("text/html;charset=UTF-8", contentType);
+	}
+
+}

--- a/test/jstachio-test-spring-example/src/test/java/io/jstach/test/opt/spring/example/package-info.java
+++ b/test/jstachio-test-spring-example/src/test/java/io/jstach/test/opt/spring/example/package-info.java
@@ -1,0 +1,1 @@
+package io.jstach.test.opt.spring.example;

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -14,6 +14,7 @@
   <modules>
     <module>examples</module>
     <module>jstachio-test-stache</module>
+    <module>jstachio-test-spring-example</module>
   </modules>
   <build>
     <pluginManagement>
@@ -35,4 +36,48 @@
       </plugins>
     </pluginManagement>
   </build>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>6.0.0</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.jstach</groupId>
+        <artifactId>jstachio-jmustache</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jstach</groupId>
+        <artifactId>jstachio-spring</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jstach</groupId>
+        <artifactId>jstachio-spring-webmvc</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jstach</groupId>
+        <artifactId>jstachio-spring-webflux</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>


### PR DESCRIPTION
@dsyer I'm not sure about Spring's MediaType and if I'm using it correctly.

One thing I did miss is the View was not using the newer output stream work which will use pre-encoding. That is fixed and so is the content type.

Because Spring seems to take preference on `View` returns and ignores `@ResponseBody` only these two use the `MessageConverter`:

http://localhost:8080/templateModel

http://localhost:8080/responseEntity


However the problem with the above (MessageConverter) is the Transfer-Encoding is "chunked". This is bad for HTML. TechEmpower benchmark will straight up disqualify for that. 