### PR TITLE
Fix #176 webflux content type and char set issues

### DIFF
--- a/opt/jstachio-spring-webflux-example/src/main/java/io/jstach/opt/spring/webflux/example/WebConfig.java
+++ b/opt/jstachio-spring-webflux-example/src/main/java/io/jstach/opt/spring/webflux/example/WebConfig.java
@@ -8,17 +8,17 @@ import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
 
 import io.jstach.jstachio.JStachio;
-import io.jstach.opt.spring.web.JStachioHttpMessageConverter;
 import io.jstach.opt.spring.webflux.JStachioEncoder;
 import io.jstach.opt.spring.webflux.JStachioModelViewConfigurer;
 import io.jstach.opt.spring.webflux.ViewSetupBeanPostProcessor;
 
 /**
- * Configures MVC using {@link JStachioHttpMessageConverter} to allow returning models
- * which will be rendered using JStachio runtime.
+ * Configures WebFlux using {@link JStachioEncoder} to allow returning models which will
+ * be rendered using JStachio runtime.
  *
  * @author agentgt
- * @see JStachioHttpMessageConverter
+ * @author dsyer
+ * @see JStachioEncoder
  */
 @SuppressWarnings("exports")
 @Configuration
@@ -37,6 +37,9 @@ public class WebConfig implements WebFluxConfigurer {
 
 	@Override
 	public void configureHttpMessageCodecs(ServerCodecConfigurer configurer) {
+		/*
+		 * TODO consider using HttpMessageWriter on minor release
+		 */
 		configurer.customCodecs().register(new JStachioEncoder(jstachio));
 	}
 

--- a/opt/jstachio-spring-webflux-example/src/main/java/io/jstach/opt/spring/webflux/example/hello/HelloController.java
+++ b/opt/jstachio-spring-webflux-example/src/main/java/io/jstach/opt/spring/webflux/example/hello/HelloController.java
@@ -38,7 +38,7 @@ public class HelloController {
 	@GetMapping(value = "/")
 	@ResponseBody
 	public HelloModel hello() {
-		return new HelloModel("Spring Boot is now JStachioed!");
+		return new HelloModel("Spring Boot WebFlux is now JStachioed!");
 	}
 
 	/**
@@ -54,9 +54,9 @@ public class HelloController {
 	 * @return the model that will be used as View
 	 * @see JStachioHttpMessageConverter
 	 */
-	@GetMapping(value = "/webflux")
+	@GetMapping(value = "/mvc")
 	public View mvc() {
-		return JStachioModelView.of(new HelloModel("Spring Boot WebFlux is now JStachioed!"));
+		return JStachioModelView.of(new HelloModel("Spring Boot WebFlux View is now JStachioed!"));
 	}
 
 }

--- a/opt/jstachio-spring-webflux/src/main/java/io/jstach/opt/spring/webflux/JStachioEncoder.java
+++ b/opt/jstachio-spring-webflux/src/main/java/io/jstach/opt/spring/webflux/JStachioEncoder.java
@@ -1,5 +1,8 @@
 package io.jstach.opt.spring.webflux;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -10,6 +13,7 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.http.MediaType;
 import org.springframework.util.MimeType;
+import org.springframework.web.server.NotAcceptableStatusException;
 
 import io.jstach.jstachio.JStachio;
 import io.jstach.jstachio.Template;
@@ -29,12 +33,24 @@ public class JStachioEncoder extends AbstractSingleValueEncoder<Object> {
 
 	private final int allocateBufferSize;
 
+	private final MediaType mediaType;
+
+	/**
+	 * TODO make public on minor release
+	 */
+	static final int DEFAULT_BUFFER_SIZE = 4 * 1024;
+
+	/**
+	 * The default media type is "<code>text/html; charset=UTF-8</code>".
+	 */
+	static final MediaType DEFAULT_MEDIA_TYPE = new MediaType(MediaType.TEXT_HTML, StandardCharsets.UTF_8);
+
 	/**
 	 * Create the encoder from a JStachio
 	 * @param jstachio not <code>null</code>.
 	 */
 	public JStachioEncoder(JStachio jstachio) {
-		this(jstachio, 4 * 1024);
+		this(jstachio, DEFAULT_BUFFER_SIZE);
 	}
 
 	/**
@@ -43,14 +59,26 @@ public class JStachioEncoder extends AbstractSingleValueEncoder<Object> {
 	 * @param allocateBufferSize how much to initially allocate from the buffer factory
 	 */
 	public JStachioEncoder(JStachio jstachio, int allocateBufferSize) {
-		super(MediaType.TEXT_HTML);
+		this(jstachio, allocateBufferSize, DEFAULT_MEDIA_TYPE);
+	}
+
+	/*
+	 * TODO possibly make public on minor release
+	 */
+	JStachioEncoder(JStachio jstachio, int allocateBufferSize, MediaType mediaType) {
+		super(mediaType);
 		this.jstachio = jstachio;
 		this.allocateBufferSize = allocateBufferSize;
+		this.mediaType = mediaType;
 	}
 
 	@Override
 	public boolean canEncode(ResolvableType elementType, @Nullable MimeType mimeType) {
 		Class<?> clazz = elementType.toClass();
+		/*
+		 * WE MUST BLOCK all other encoders regardless of mimetype if it is a jstache
+		 * model otherwise we could serialize a model that has sensitive data as JSON.
+		 */
 		return clazz != Object.class && !CharSequence.class.isAssignableFrom(clazz) && jstachio.supportsType(clazz);
 	}
 
@@ -62,12 +90,45 @@ public class JStachioEncoder extends AbstractSingleValueEncoder<Object> {
 
 	@Override
 	public DataBuffer encodeValue(Object event, DataBufferFactory bufferFactory, ResolvableType valueType,
-			MimeType mimeType, Map<String, Object> hints) {
+			@Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
 		if (logger.isDebugEnabled() && !Hints.isLoggingSuppressed(hints)) {
 			String logPrefix = Hints.getLogPrefix(hints);
 			logger.debug(logPrefix + "Writing [" + event + "]");
 		}
 
+		/*
+		 * We check the media type to see if it matches otherwise Spring will default to
+		 * application/json and will send Content-Type application/json back but return
+		 * our almost always NOT JSON body (jstachio should obviously not be used for
+		 * generating json).
+		 *
+		 * See #176
+		 */
+		if (mimeType != null && !mimeType.isCompatibleWith(this.mediaType)) {
+			/*
+			 * Returning 406 is not ideal for HTML responses
+			 *
+			 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406
+			 *
+			 * > In practice, this error is very rarely used. Instead of responding using
+			 * this > error code, which would be cryptic for the end user and difficult to
+			 * fix, > servers ignore the relevant header and serve an actual page to the
+			 * user. It > is assumed that even if the user won't be completely happy, they
+			 * will prefer > this to an error code.
+			 */
+			throw new NotAcceptableStatusException(List.of(this.mediaType));
+		}
+
+		return encode(jstachio, event, bufferFactory, allocateBufferSize, this.mediaType.getCharset());
+
+	}
+
+	static DataBuffer encode( //
+			JStachio jstachio, //
+			Object event, //
+			DataBufferFactory bufferFactory, //
+			int bufferSize, //
+			@Nullable Charset charset) {
 		Template<Object> template;
 		try {
 			template = jstachio.findTemplate(event);
@@ -75,12 +136,13 @@ public class JStachioEncoder extends AbstractSingleValueEncoder<Object> {
 		catch (Exception e) {
 			throw new RuntimeException(e);
 		}
+		if (charset == null) {
+			charset = template.templateCharset();
+		}
 
-		DataBufferOutput output = new DataBufferOutput(bufferFactory.allocateBuffer(allocateBufferSize),
-				template.templateCharset());
+		DataBufferOutput output = new DataBufferOutput(bufferFactory.allocateBuffer(bufferSize), charset);
 
 		return template.write(event, output).getBuffer();
-
 	}
 
 }

--- a/opt/jstachio-spring-webflux/src/main/java/io/jstach/opt/spring/webflux/JStachioModelView.java
+++ b/opt/jstachio-spring-webflux/src/main/java/io/jstach/opt/spring/webflux/JStachioModelView.java
@@ -1,9 +1,10 @@
 package io.jstach.opt.spring.webflux;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.Nullable;
+import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.result.view.AbstractView;
 import org.springframework.web.reactive.result.view.View;
@@ -28,7 +29,10 @@ import reactor.core.publisher.Mono;
 public interface JStachioModelView extends View {
 
 	@Override
-	default Mono<Void> render(Map<String, ?> model, MediaType contentType, ServerWebExchange exchange) {
+	default Mono<Void> render( //
+			@Nullable Map<String, ?> model, //
+			@Nullable MediaType contentType, //
+			ServerWebExchange exchange) {
 		if (contentType != null) {
 			exchange.getResponse().getHeaders().setContentType(contentType);
 		}
@@ -39,17 +43,27 @@ public interface JStachioModelView extends View {
 		View view = new AbstractView() {
 
 			@Override
-			protected Mono<Void> renderInternal(Map<String, Object> model, MediaType contentType,
+			protected Mono<Void> renderInternal(Map<String, Object> model, @Nullable MediaType contentType,
 					ServerWebExchange exchange) {
-				return exchange.getResponse().writeWith(Mono.fromCallable(() -> {
-					try {
-						byte[] bytes = String.valueOf(jstachio().execute(model())).getBytes(StandardCharsets.UTF_8);
-						// just wrapping, no allocation
-						return exchange.getResponse().bufferFactory().wrap(bytes);
-					}
-					catch (Exception ex) {
-						throw new IllegalStateException("Failed to render script template", ex);
-					}
+				var response = exchange.getResponse();
+				return response.writeWith(Mono.fromCallable(() -> {
+					var bufferFactory = response.bufferFactory();
+					var mediaType = mediaType();
+					DataBuffer buffer = JStachioEncoder.encode(jstachio(), model(), bufferFactory, bufferSize(),
+							mediaType.getCharset());
+					var headers = response.getHeaders();
+					headers.setContentType(mediaType);
+					/*
+					 * For some reason the webflux WebTestClient gets content-length of -1
+					 * during unit test but when actually deployed the pipeline will
+					 * implicitly set the content length.
+					 *
+					 * So we just go ahead and explicitely set hoping that does not hurt
+					 * anything.
+					 */
+					int length = buffer.readableByteCount();
+					headers.setContentLength(length);
+					return buffer;
 				}));
 			}
 
@@ -60,7 +74,7 @@ public interface JStachioModelView extends View {
 
 	@Override
 	default List<MediaType> getSupportedMediaTypes() {
-		return List.of(MediaType.TEXT_HTML);
+		return List.of(mediaType());
 	}
 
 	/**
@@ -81,11 +95,31 @@ public interface JStachioModelView extends View {
 	}
 
 	/**
+	 * The initial size of the buffer allocated to be used for rendering.
+	 * @return buffer size the default is 4K.
+	 */
+	default int bufferSize() {
+		return JStachioEncoder.DEFAULT_BUFFER_SIZE;
+	}
+
+	/**
+	 * The default media type for the view.
+	 * @return media type the default is "<code>text/html; charset=UTF-8</code>"
+	 */
+	default MediaType mediaType() {
+		return JStachioEncoder.DEFAULT_MEDIA_TYPE;
+	}
+
+	/**
 	 * Creates a spring view from a model
 	 * @param model an instance of a class annotated with {@link JStache}.
 	 * @return view ready for rendering
 	 */
 	public static JStachioModelView of(Object model) {
+		/*
+		 * TODO in theory we could resolve media type here by finding the template right
+		 * away.
+		 */
 		return new JStachioModelView() {
 			@Override
 			public Object model() {

--- a/test/jstachio-test-spring-example/src/test/java/io/jstach/test/opt/spring/example/package-info.java
+++ b/test/jstachio-test-spring-example/src/test/java/io/jstach/test/opt/spring/example/package-info.java
@@ -1,1 +1,2 @@
+@org.eclipse.jdt.annotation.NonNullByDefault
 package io.jstach.test.opt.spring.example;

--- a/test/jstachio-test-spring-webflux-example/pom.xml
+++ b/test/jstachio-test-spring-webflux-example/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.jstach</groupId>
+    <artifactId>jstachio-test-parent</artifactId>
+    <version>1.2.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>jstachio-test-spring-webflux-example</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>jstachio-spring-webflux-example</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/test/jstachio-test-spring-webflux-example/src/test/java/io/jstach/test/opt/spring/webflux/example/HelloControllerTest.java
+++ b/test/jstachio-test-spring-webflux-example/src/test/java/io/jstach/test/opt/spring/webflux/example/HelloControllerTest.java
@@ -1,0 +1,135 @@
+package io.jstach.test.opt.spring.webflux.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import io.jstach.opt.spring.webflux.example.App;
+import io.jstach.opt.spring.webflux.example.SpringTemplateConfig;
+import io.jstach.opt.spring.webflux.example.WebConfig;
+
+@SpringBootTest(classes = { App.class, WebConfig.class, SpringTemplateConfig.class })
+@AutoConfigureWebTestClient
+public class HelloControllerTest {
+
+	@Autowired
+	WebTestClient client;
+	static final String ENCODER_BODY = """
+			<!doctype html>
+			<html lang="en">
+			  <head>
+			    <meta charset="utf-8">
+			    <meta name="viewport" content="width=device-width, initial-scale=1">
+			    <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css">
+			    <title>Hello, Spring Boot WebFlux is now JStachioed!!</title>
+			  </head>
+			  <body>
+			    <main class="container">
+			      <h1>Spring Boot WebFlux is now JStachioed!</h1>
+			    </main>
+			  </body>
+			</html>""";
+	static final String VIEW_BODY = """
+			<!doctype html>
+			<html lang="en">
+			  <head>
+			    <meta charset="utf-8">
+			    <meta name="viewport" content="width=device-width, initial-scale=1">
+			    <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css">
+			    <title>Hello, Spring Boot WebFlux View is now JStachioed!!</title>
+			  </head>
+			  <body>
+			    <main class="container">
+			      <h1>Spring Boot WebFlux View is now JStachioed!</h1>
+			    </main>
+			  </body>
+			</html>""";
+
+	@ParameterizedTest
+	@ValueSource(strings = { "text/html", "*/*", /* "application/json" */ })
+	public void testEncoder(String mediaType) {
+		String path = "/";
+		String expected = ENCODER_BODY;
+		MediaType accept = MediaType.parseMediaType(mediaType);
+		assertEndpoint(path, expected, accept);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "application/json", "application/fake" })
+	public void testEncoderBadMediaType(String mediaType) {
+		String path = "/";
+		MediaType accept = MediaType.parseMediaType(mediaType);
+		/*
+		 * This is not ideal
+		 *
+		 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406
+		 *
+		 * In practice, this error is very rarely used. Instead of responding using this
+		 * error code, which would be cryptic for the end user and difficult to fix,
+		 * servers ignore the relevant header and serve an actual page to the user. It is
+		 * assumed that even if the user won't be completely happy, they will prefer this
+		 * to an error code.
+		 */
+		client.get().uri(path) //
+				.accept(accept) //
+				.exchange() //
+				.expectStatus() //
+				.isEqualTo(HttpStatusCode.valueOf(406));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "text/html", "*/*", /* "application/json" */ })
+	public void testView(String mediaType) {
+		String path = "/mvc";
+		String expected = VIEW_BODY;
+		MediaType accept = MediaType.parseMediaType(mediaType);
+		assertEndpoint(path, expected, accept);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "application/json", "application/fake" })
+	public void testViewBadMediaType(String mediaType) {
+		String path = "/mvc";
+		MediaType accept = MediaType.parseMediaType(mediaType);
+		/*
+		 * This is not ideal
+		 *
+		 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406
+		 *
+		 * In practice, this error is very rarely used. Instead of responding using this
+		 * error code, which would be cryptic for the end user and difficult to fix,
+		 * servers ignore the relevant header and serve an actual page to the user. It is
+		 * assumed that even if the user won't be completely happy, they will prefer this
+		 * to an error code.
+		 */
+		client.get().uri(path) //
+				.accept(accept) //
+				.exchange() //
+				.expectStatus() //
+				.isEqualTo(HttpStatusCode.valueOf(406));
+	}
+
+	void assertEndpoint(String path, String expected, MediaType accept) {
+		long contentLength = expected.getBytes(StandardCharsets.UTF_8).length;
+		EntityExchangeResult<byte[]> result = client.get().uri(path) //
+				.accept(accept) //
+				.exchange().expectHeader().contentType("text/html;charset=UTF-8") //
+				.expectBody() //
+				.returnResult();
+		String actual = new String(result.getResponseBody(), StandardCharsets.UTF_8);
+		assertEquals(expected, actual);
+		long actualLength = result.getResponseHeaders().getContentLength();
+		assertEquals(contentLength, actualLength);
+	}
+
+}

--- a/test/jstachio-test-spring-webflux-example/src/test/java/io/jstach/test/opt/spring/webflux/example/package-info.java
+++ b/test/jstachio-test-spring-webflux-example/src/test/java/io/jstach/test/opt/spring/webflux/example/package-info.java
@@ -1,0 +1,2 @@
+@org.eclipse.jdt.annotation.NonNullByDefault
+package io.jstach.test.opt.spring.webflux.example;

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -15,6 +15,7 @@
     <module>examples</module>
     <module>jstachio-test-stache</module>
     <module>jstachio-test-spring-example</module>
+    <module>jstachio-test-spring-webflux-example</module>
   </modules>
   <build>
     <pluginManagement>


### PR DESCRIPTION
This fix mostly handles it with the unfortunate consequence of doing a 406 if the mime type does not match the default of HTML.