### PR TITLE
Add context aware support #168

### DIFF
--- a/api/annotation/src/main/java/io/jstach/jstache/JStacheFlags.java
+++ b/api/annotation/src/main/java/io/jstach/jstache/JStacheFlags.java
@@ -154,7 +154,13 @@ public @interface JStacheFlags {
 		 * code will not implement
 		 * <code>io.jstach.jstachio.Template.EncodedTemplate</code>.
 		 */
-		PRE_ENCODE_DISABLE;
+		PRE_ENCODE_DISABLE,
+
+		/**
+		 * <strong>EXPERIMENTAL:</strong> Will bind "@context" with a ContextNode. This is
+		 * to add cross cutting variables that the model does not have such CSRF.
+		 */
+		CONTEXT_SUPPORT;
 
 	}
 

--- a/api/jstachio/src/main/java/io/jstach/jstachio/Formatter.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/Formatter.java
@@ -234,6 +234,29 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	}
 
 	/**
+	 * Formats the formattable object and then sends the results to the downstream
+	 * appender. The default implementation calls
+	 * {@link #format(Appender, Output, String, Class, Object)} and it is generally
+	 * recommend you override for performance.
+	 *
+	 * @apiNote Although the formatter has access to the raw {@link Appendable} the
+	 * formatter should never use it directly and simply pass it on to the downstream
+	 * appender. Also take note that the string value maybe null!
+	 * @param <A> the appendable type
+	 * @param <E> the appender exception type
+	 * @param downstream the downstream appender to be used instead of the appendable
+	 * directly
+	 * @param a the appendable to be passed to the appender
+	 * @param path the dotted mustache like path
+	 * @param f Formattable which maybe <code>null</code>.
+	 * @throws E if the appender or appendable throws an exception
+	 */
+	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path,
+			@Nullable Formattable f) throws E {
+		format(downstream, a, path, Formatter.class, f);
+	}
+
+	/**
 	 * Adapts a function to a formatter.
 	 *
 	 * If the function is already a formatter then it is simply returned (noop). Thus it
@@ -247,6 +270,30 @@ public interface Formatter extends Function<@Nullable Object, String> {
 			return f;
 		}
 		return new ObjectFunctionFormatter(formatterFunction);
+	}
+
+	/**
+	 * Implement to allow formatting of custom objects you want to output. This is often
+	 * easier than registering custom {@link JStacheFormatterTypes} but couples model
+	 * objects to JStachio.
+	 */
+	public interface Formattable {
+
+		/**
+		 * Called by the formatter to format. Implementations can decide if they want to
+		 * use the passed in formatter to perhaps format other types.
+		 * @param <A> the appendable type
+		 * @param <E> the appender exception type
+		 * @param formatter the calling formatter
+		 * @param downstream the downstream appender to be used instead of the appendable
+		 * directly.
+		 * @param path the dotted mustache like path
+		 * @param a the appendable to be passed to the appender
+		 * @throws E if the appender or appendable throws an exception
+		 */
+		<A extends Output<E>, E extends Exception> void format(Formatter formatter, Appender downstream, String path,
+				A a) throws E;
+
 	}
 
 }

--- a/api/jstachio/src/main/java/io/jstach/jstachio/Formatter.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/Formatter.java
@@ -235,9 +235,9 @@ public interface Formatter extends Function<@Nullable Object, String> {
 
 	/**
 	 * Formats the formattable object and then sends the results to the downstream
-	 * appender. The default implementation calls
-	 * {@link #format(Appender, Output, String, Class, Object)} and it is generally
-	 * recommend you override for performance.
+	 * appender. The default implementation will call the supplied
+	 * {@linkplain Formattable} if it is not null otherwise it will call
+	 * {@link #format(Appender, Output, String, Class, Object)} to handle the null case.
 	 *
 	 * @apiNote Although the formatter has access to the raw {@link Appendable} the
 	 * formatter should never use it directly and simply pass it on to the downstream
@@ -253,7 +253,13 @@ public interface Formatter extends Function<@Nullable Object, String> {
 	 */
 	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path,
 			@Nullable Formattable f) throws E {
-		format(downstream, a, path, Formatter.class, f);
+		if (f != null) {
+			f.format(this, downstream, path, a);
+		}
+		else {
+			format(downstream, a, path, Formattable.class, null);
+
+		}
 	}
 
 	/**

--- a/api/jstachio/src/main/java/io/jstach/jstachio/Formatter.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/Formatter.java
@@ -1,5 +1,6 @@
 package io.jstach.jstachio;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -262,7 +263,7 @@ class ObjectFunctionFormatter implements Formatter {
 	@Override
 	public <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, Class<?> c,
 			@Nullable Object o) throws E {
-		String result = function.apply(o);
+		String result = Objects.requireNonNull(function.apply(o));
 		downstream.append(a, result);
 	}
 

--- a/api/jstachio/src/main/java/io/jstach/jstachio/JStachio.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/JStachio.java
@@ -3,6 +3,7 @@ package io.jstach.jstachio;
 import java.io.IOException;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
@@ -173,11 +174,7 @@ public interface JStachio extends Renderer<Object> {
 	 * @see #setStatic(Supplier)
 	 */
 	public static JStachio of() {
-		JStachio jstachio = JStachioHolder.get();
-		if (jstachio == null) {
-			throw new NullPointerException("JStachio not found. This is probably a classloading issue.");
-		}
-		return jstachio;
+		return JStachioHolder.get();
 	}
 
 	/**
@@ -197,7 +194,7 @@ public interface JStachio extends Renderer<Object> {
 	 * avoid constant recreation it is recommend the supplier be memoized/cached.
 	 */
 	public static void setStatic(Supplier<JStachio> jstachioProvider) {
-		if (jstachioProvider == null) {
+		if (Objects.isNull(jstachioProvider)) {
 			throw new NullPointerException("JStachio provider cannot be null");
 		}
 		JStachioHolder.provider = jstachioProvider;
@@ -213,7 +210,7 @@ final class JStachioHolder {
 	}
 
 	static JStachio get() {
-		return provider.get();
+		return Objects.requireNonNull(provider.get(), "JStachio not found. This is probably a classloading issue.");
 	}
 
 }

--- a/api/jstachio/src/main/java/io/jstach/jstachio/Output.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/Output.java
@@ -329,9 +329,9 @@ class OutputAppendable implements Appendable {
 	}
 
 	@Override
-	public Appendable append(@Nullable CharSequence csq) throws @Nullable IOException {
+	public Appendable append(@Nullable CharSequence csq) throws IOException {
 		try {
-			output.append(csq);
+			output.append(csq == null ? "null" : csq);
 			return this;
 		}
 		catch (Exception e) {
@@ -345,7 +345,7 @@ class OutputAppendable implements Appendable {
 	@Override
 	public Appendable append(@Nullable CharSequence csq, int start, int end) throws IOException {
 		try {
-			output.append(csq, start, end);
+			output.append(csq == null ? " null " : csq, start, end);
 			return this;
 		}
 		catch (Exception e) {

--- a/api/jstachio/src/main/java/io/jstach/jstachio/TemplateModel.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/TemplateModel.java
@@ -3,6 +3,7 @@ package io.jstach.jstachio;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -170,13 +171,13 @@ interface TemplateProxy extends Template<Object>, FilterChain {
 
 }
 
-record DefaultTemplateExecutable<T> (Template<T> delegateTemplate, T model) implements TemplateModel, TemplateProxy {
+record DefaultTemplateExecutable<T> (Template<T> delegateTemplate, T _model) implements TemplateModel, TemplateProxy {
 
 	static final String ERROR_MESSAGE = "The model passed into this TemplateModel is not correct";
 
 	@Override
 	public <A extends io.jstach.jstachio.Output<E>, E extends Exception> A execute(A output) throws E {
-		return delegateTemplate.execute(model(), output);
+		return delegateTemplate.execute(this._model, output);
 	}
 
 	@Override
@@ -185,8 +186,13 @@ record DefaultTemplateExecutable<T> (Template<T> delegateTemplate, T model) impl
 	}
 
 	@Override
+	public Object model() {
+		return Objects.requireNonNull(_model);
+	}
+
+	@Override
 	public <A extends Output<E>, E extends Exception> A execute(Object model, A appendable) throws E {
-		if (model == this || model == this.model) {
+		if (model == this || model == this._model) {
 			return execute(appendable);
 		}
 		throw new UnsupportedOperationException(ERROR_MESSAGE);
@@ -195,26 +201,31 @@ record DefaultTemplateExecutable<T> (Template<T> delegateTemplate, T model) impl
 }
 
 record EncodedTemplateExecutable<T> (EncodedTemplate<T> delegateTemplate,
-		T model) implements TemplateModel, TemplateProxy {
+		T _model) implements TemplateModel, TemplateProxy {
 
 	@Override
 	public <A extends io.jstach.jstachio.Output<E>, E extends Exception> A execute(A output) throws E {
-		return delegateTemplate.execute(model(), output);
+		return delegateTemplate.execute(this._model, output);
 	}
 
 	@Override
 	public <A extends EncodedOutput<E>, E extends Exception> A write(A output) throws E {
-		return delegateTemplate.write(model, output);
+		return delegateTemplate.write(_model, output);
 	}
 
 	@Override
 	public Template<?> template() {
 		return this;
 	}
+	
+	@Override
+	public Object model() {
+		return Objects.requireNonNull(_model);
+	}
 
 	@Override
 	public <A extends Output<E>, E extends Exception> A execute(Object model, A appendable) throws E {
-		if (model == this || model == this.model) {
+		if (model == this || model == this._model) {
 			return execute(appendable);
 		}
 		throw new UnsupportedOperationException(DefaultTemplateExecutable.ERROR_MESSAGE);
@@ -222,7 +233,7 @@ record EncodedTemplateExecutable<T> (EncodedTemplate<T> delegateTemplate,
 
 	@Override
 	public <A extends EncodedOutput<E>, E extends Exception> A write(Object model, A appendable) throws E {
-		if (model == this || model == this.model) {
+		if (model == this || model == this._model) {
 			return write(appendable);
 		}
 		throw new UnsupportedOperationException(DefaultTemplateExecutable.ERROR_MESSAGE);

--- a/api/jstachio/src/main/java/io/jstach/jstachio/TemplateModel.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/TemplateModel.java
@@ -217,7 +217,7 @@ record EncodedTemplateExecutable<T> (EncodedTemplate<T> delegateTemplate,
 	public Template<?> template() {
 		return this;
 	}
-	
+
 	@Override
 	public Object model() {
 		return Objects.requireNonNull(_model);

--- a/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextAwareOutput.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextAwareOutput.java
@@ -1,22 +1,23 @@
-package io.jstach.jstachio.output;
+package io.jstach.jstachio.context;
 
 import io.jstach.jstachio.Output;
 import io.jstach.jstachio.Output.EncodedOutput;
-import io.jstach.jstachio.context.ContextNode;
-import io.jstach.jstachio.context.ContextSupplier;
+import io.jstach.jstachio.output.ForwardingEncodedOutput;
+import io.jstach.jstachio.output.ForwardingOutput;
 
 /**
  * Decorate outputs with a context.
  *
  * @author agentgt
+ * @see ContextJStachio
  */
-public sealed interface ContextAwareOutput<O> extends ContextSupplier {
+sealed interface ContextAwareOutput<O> extends ContextSupplier {
 
 	/**
 	 * The original output
 	 * @return the original output
 	 */
-	public O getOutput();
+	O getOutput();
 
 	/**
 	 * Wrap an output with a context.
@@ -26,7 +27,7 @@ public sealed interface ContextAwareOutput<O> extends ContextSupplier {
 	 * @param context context to use
 	 * @return decorated output
 	 */
-	public static <E extends Exception, O extends Output<E>> ContextOutput<E, O> of(O output, ContextNode context) {
+	static <E extends Exception, O extends Output<E>> ContextOutput<E, O> of(O output, ContextNode context) {
 		return new ContextOutput<>(output, context);
 	}
 
@@ -38,7 +39,7 @@ public sealed interface ContextAwareOutput<O> extends ContextSupplier {
 	 * @param context context to use
 	 * @return decorated output
 	 */
-	public static <E extends Exception, O extends EncodedOutput<E>> ContextEncodedOutput<E, O> of(O output,
+	static <E extends Exception, O extends EncodedOutput<E>> ContextEncodedOutput<E, O> of(O output,
 			ContextNode context) {
 		return new ContextEncodedOutput<>(output, context);
 	}
@@ -49,7 +50,7 @@ public sealed interface ContextAwareOutput<O> extends ContextSupplier {
 	 * @param <E> exception type
 	 * @param <O> output type
 	 */
-	public final class ContextOutput<E extends Exception, O extends Output<E>> extends ForwardingOutput<E>
+	final class ContextOutput<E extends Exception, O extends Output<E>> extends ForwardingOutput<E>
 			implements ContextAwareOutput<O> {
 
 		private final O output;

--- a/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextJStachio.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextJStachio.java
@@ -1,14 +1,18 @@
 package io.jstach.jstachio.context;
 
+import java.io.IOException;
+
 import io.jstach.jstache.JStacheConfig;
 import io.jstach.jstachio.JStachio;
 import io.jstach.jstachio.Output;
+import io.jstach.jstachio.Output.EncodedOutput;
+import io.jstach.jstachio.Template;
 
 /**
  * See {@link JStachio}. A special JStachio that can render models with a loose typed
  * context object bound to {@value ContextNode#CONTEXT_BINDING_NAME}.
  */
-public interface ContextJStachio {
+public interface ContextJStachio extends JStachio {
 
 	/**
 	 * Renders the passed in model.
@@ -42,5 +46,72 @@ public interface ContextJStachio {
 			Object model, //
 			ContextNode context, //
 			A output) throws E;
+
+	/**
+	 * Decorates a JStachio instance as a {@link ContextJStachio} if it is not already
+	 * one.
+	 * @param jstachio the instance to be wrapped.
+	 * @return the passed in jstachio if it is already a {@link ContextJStachio} otherwise
+	 * wraps the passed in instance.
+	 */
+	public static ContextJStachio of(JStachio jstachio) {
+		if (jstachio instanceof ContextJStachio cj) {
+			return cj;
+		}
+		return new ForwardingJStachio(jstachio);
+	}
+
+}
+
+record ForwardingJStachio(JStachio delegate) implements ContextJStachio {
+
+	@Override
+	public <A extends Output<E>, E extends Exception> A execute(Object model, A appendable) throws E {
+		return delegate.execute(model, appendable);
+	}
+
+	@Override
+	public <A extends EncodedOutput<E>, E extends Exception> A write(Object model, A output) throws E {
+		return delegate.write(model, output);
+	}
+
+	@Override
+	public Template<Object> findTemplate(Object model) throws Exception {
+		return delegate.findTemplate(model);
+	}
+
+	@Override
+	public boolean supportsType(Class<?> modelType) {
+		return delegate.supportsType(modelType);
+	}
+
+	@Override
+	public void execute(Object model, Appendable appendable) throws IOException {
+		delegate.execute(model, appendable);
+	}
+
+	@Override
+	public StringBuilder execute(Object model, StringBuilder sb) {
+		return delegate.execute(model, sb);
+	}
+
+	@Override
+	public String execute(Object model) {
+		return delegate.execute(model);
+	}
+
+	@Override
+	public <A extends Output<E>, E extends Exception> A execute(Object model, ContextNode context, A appendable)
+			throws E {
+		var out = ContextAwareOutput.of(appendable, context);
+		return delegate.execute(model, out).getOutput();
+	}
+
+	@Override
+	public <A extends EncodedOutput<E>, E extends Exception> A write(Object model, ContextNode context, A output)
+			throws E {
+		var out = ContextAwareOutput.of(output, context);
+		return delegate.write(model, out).getOutput();
+	}
 
 }

--- a/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextJStachio.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextJStachio.java
@@ -1,0 +1,46 @@
+package io.jstach.jstachio.context;
+
+import io.jstach.jstache.JStacheConfig;
+import io.jstach.jstachio.JStachio;
+import io.jstach.jstachio.Output;
+
+/**
+ * See {@link JStachio}. A special JStachio that can render models with a loose typed
+ * context object bound to {@value ContextNode#CONTEXT_BINDING_NAME}.
+ */
+public interface ContextJStachio {
+
+	/**
+	 * Renders the passed in model.
+	 * @param <A> output type
+	 * @param <E> error type
+	 * @param model a model assumed never to be <code>null</code>.
+	 * @param context context node.
+	 * @param appendable the output to write to.
+	 * @return the output passed in returned for convenience.
+	 * @throws E if there is an error writing to the output
+	 */
+	public <A extends Output<E>, E extends Exception> A execute(Object model, //
+			ContextNode context, //
+			A appendable) throws E;
+
+	/**
+	 * Renders the passed in model <strong>with a context</strong> directly to a binary
+	 * stream leveraging pre-encoded parts of the template. This <em>may</em> improve
+	 * performance when rendering UTF-8 to an OutputStream as some of the encoding is done
+	 * in advance. Because the encoding is done statically you cannot pass the charset in.
+	 * The chosen charset comes from {@link JStacheConfig#charset()}.
+	 * @param <A> output type
+	 * @param <E> error type
+	 * @param model a model assumed never to be <code>null</code>.
+	 * @param context context node.
+	 * @param output to write to.
+	 * @return the passed in output for convenience
+	 * @throws E if an error occurs while writing to output
+	 */
+	<A extends io.jstach.jstachio.Output.EncodedOutput<E>, E extends Exception> A write( //
+			Object model, //
+			ContextNode context, //
+			A output) throws E;
+
+}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextNode.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextNode.java
@@ -64,6 +64,11 @@ import io.jstach.jstachio.context.Internal.FunctionContextNode;
 public sealed interface ContextNode extends Formattable, Iterable<@Nullable ContextNode> {
 
 	/**
+	 * The default binding name for context.
+	 */
+	public static final String CONTEXT_BINDING_NAME = "@context";
+
+	/**
 	 * Creates a root context node with the given function to look up children.
 	 * @param function used to find children with a given name
 	 * @return root context node powered by a function
@@ -111,14 +116,6 @@ public sealed interface ContextNode extends Formattable, Iterable<@Nullable Cont
 			return resolve(second);
 		}
 		return f;
-	}
-
-	/**
-	 * Internal for suppress unused warnings for context node variable.
-	 * @param node node
-	 * @apiNote ignore. For code generation purposes.
-	 */
-	public static void suppressUnused(ContextNode node) {
 	}
 
 	/**

--- a/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextNode.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextNode.java
@@ -69,20 +69,6 @@ public interface ContextNode extends Iterable<ContextNode> {
 	}
 
 	/**
-	 * Creates a root context node with the given function to look up children and if any
-	 * child is missing will throw a {@link NullPointerException}.
-	 * @param function used to find children with a given name
-	 * @return root context node powered by a function
-	 * @apiNote Unlike many other methods in this class this is not nullable.
-	 */
-	public static ContextNode ofNonNull(Function<String, ?> function) {
-		if (function == null) {
-			throw new NullPointerException("function is required");
-		}
-		return new NonNullFunctionContextNode(function);
-	}
-
-	/**
 	 * An empty context node that is safe to use identify comparison.
 	 * @return empty singleton context node
 	 */
@@ -353,32 +339,6 @@ public interface ContextNode extends Iterable<ContextNode> {
 
 }
 
-interface NonNullContextNode extends ContextNode {
-
-	@Override
-	default ContextNode ofChild(String name, @Nullable Object o) throws IllegalArgumentException {
-		if (o == null) {
-			throw new NullPointerException("Child is null at field: " + name);
-		}
-		if (o instanceof ContextNode) {
-			throw new IllegalArgumentException("Cannot wrap ContextNode around another ContextNode");
-		}
-		return new NamedContextNode(this, o, name);
-	}
-
-	@Override
-	default ContextNode ofChild(int index, @Nullable Object o) {
-		if (o == null) {
-			throw new NullPointerException("Child is null at index: " + index);
-		}
-		if (o instanceof ContextNode) {
-			throw new IllegalArgumentException("Cannot wrap ContextNode around another ContextNode");
-		}
-		return new NonNullIndexedContextNode(this, o, index);
-	}
-
-}
-
 record RootContextNode(Object object) implements ContextNode {
 	@Override
 	public String toString() {
@@ -407,33 +367,6 @@ record NamedContextNode(ContextNode parent, Object object, String name) implemen
 }
 
 record IndexedContextNode(ContextNode parent, Object object, int index) implements ContextNode {
-	@Override
-	public String toString() {
-		return renderString();
-	}
-}
-
-record NonNullFunctionContextNode(Function<String, ?> object) implements NonNullContextNode {
-	@Override
-	public String toString() {
-		return renderString();
-	}
-
-	@Override
-	public @Nullable ContextNode get(String field) {
-		return ofChild(field, object().apply(field));
-	}
-
-}
-
-record NonNullNamedContextNode(ContextNode parent, Object object, String name) implements NonNullContextNode {
-	@Override
-	public String toString() {
-		return renderString();
-	}
-}
-
-record NonNullIndexedContextNode(ContextNode parent, Object object, int index) implements NonNullContextNode {
 	@Override
 	public String toString() {
 		return renderString();

--- a/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextNode.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextNode.java
@@ -9,26 +9,44 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * This interface serves two puproses:
+ * This interface serves three puproses:
  *
  * <ol>
  * <li>A way to represent the current context stack (see {@link #parent()})
  * <li>Allow you to simulate JSON/Javscript object node like trees without being coupled
  * to a particularly JSON lib.
+ * <li>Represent per request context data in a web framework like CSRF tokens.
  * </ol>
  * The interface simply wraps {@link Map} and {@link Iterable} (and arrays) lazily through
  * composition but generally cannot wrap other context nodes. If an object is wrapped that
  * is not a Map or Iterable it becomes a leaf node similar to JSON.
  * <p>
  * It is not recommended you use this interface as it avoids much of the type checking
- * safty of this library as well as increase coupling however it does provide a slightly
- * better bridge to legacy {@code Map<String,?>} models over using the maps directly.
+ * safty of this library, decreases performance as well as increase coupling however it
+ * does provide a slightly better bridge to legacy {@code Map<String,?>} models over using
+ * the maps directly.
+ * <p>
+ * Context Node while similar to a Map does not follow the same rules of resolution where
+ * Map resolves bindings always last. It will resolve first and thus it is easy to
+ * accidentally get stuck in the Context Node context. To prevent this it is highly
+ * recommended you do not open a context node with a section block and prefer dotted
+ * notation to access it.
+ *
+ * <h2>Example:</h2>
+ *
+ * <pre><code class="language-hbs">
+ * {{message}}
+ * {{#&#64;context}}
+ * {{message}} {{! message here will only ever resolve against &#64;context and not the parent }}
+ * {{/&#64;context}}
+ * </code> </pre>
  *
  * @apiNote The parents do not know anything about their children as it is the child that
  * has reference to the parent.
@@ -36,6 +54,77 @@ import org.eclipse.jdt.annotation.Nullable;
  *
  */
 public interface ContextNode extends Iterable<ContextNode> {
+
+	/**
+	 * Creates a root context node with the given function to look up children.
+	 * @param function used to find children with a given name
+	 * @return root context node powered by a function
+	 * @apiNote Unlike many other methods in this class this is not nullable.
+	 */
+	public static ContextNode of(Function<String, ?> function) {
+		if (function == null) {
+			throw new NullPointerException("function is required");
+		}
+		return new FunctionContextNode(function);
+	}
+
+	/**
+	 * Creates a root context node with the given function to look up children and if any
+	 * child is missing will throw a {@link NullPointerException}.
+	 * @param function used to find children with a given name
+	 * @return root context node powered by a function
+	 * @apiNote Unlike many other methods in this class this is not nullable.
+	 */
+	public static ContextNode ofNonNull(Function<String, ?> function) {
+		if (function == null) {
+			throw new NullPointerException("function is required");
+		}
+		return new NonNullFunctionContextNode(function);
+	}
+
+	/**
+	 * An empty context node that is safe to use identify comparison.
+	 * @return empty singleton context node
+	 */
+	public static ContextNode empty() {
+		return EmptyContextNode.EMPTY;
+	}
+
+	/**
+	 * Resolves the context node from an object.
+	 * @param o object that maybe a context or have a context.
+	 * @return {@link #empty()} if not found.
+	 */
+	public static ContextNode resolve(Object o) {
+		if (o instanceof ContextSupplier cs) {
+			return cs.context();
+		}
+		if (o instanceof ContextNode n) {
+			return n;
+		}
+		return ContextNode.empty();
+	}
+
+	/**
+	 * Internal for suppress unused warnings for context node variable.
+	 * @param node node
+	 */
+	public static void suppressUnused(ContextNode node) {
+	}
+
+	/**
+	 * Resolves the context node trying first and then second.
+	 * @param first first object to try
+	 * @param second second object to try
+	 * @return {@link #empty()} if not found.
+	 */
+	public static ContextNode resolve(Object first, Object second) {
+		var f = resolve(first);
+		if (f == ContextNode.empty()) {
+			return resolve(second);
+		}
+		return f;
+	}
 
 	/**
 	 * Creates the root node which has no name.
@@ -55,7 +144,6 @@ public interface ContextNode extends Iterable<ContextNode> {
 			return n;
 		}
 		return new RootContextNode(o);
-
 	}
 
 	/**
@@ -265,11 +353,50 @@ public interface ContextNode extends Iterable<ContextNode> {
 
 }
 
+interface NonNullContextNode extends ContextNode {
+
+	@Override
+	default ContextNode ofChild(String name, @Nullable Object o) throws IllegalArgumentException {
+		if (o == null) {
+			throw new NullPointerException("Child is null at field: " + name);
+		}
+		if (o instanceof ContextNode) {
+			throw new IllegalArgumentException("Cannot wrap ContextNode around another ContextNode");
+		}
+		return new NamedContextNode(this, o, name);
+	}
+
+	@Override
+	default ContextNode ofChild(int index, @Nullable Object o) {
+		if (o == null) {
+			throw new NullPointerException("Child is null at index: " + index);
+		}
+		if (o instanceof ContextNode) {
+			throw new IllegalArgumentException("Cannot wrap ContextNode around another ContextNode");
+		}
+		return new NonNullIndexedContextNode(this, o, index);
+	}
+
+}
+
 record RootContextNode(Object object) implements ContextNode {
 	@Override
 	public String toString() {
 		return renderString();
 	}
+}
+
+record FunctionContextNode(Function<String, ?> object) implements ContextNode {
+	@Override
+	public String toString() {
+		return renderString();
+	}
+
+	@Override
+	public @Nullable ContextNode get(String field) {
+		return ofChild(field, object().apply(field));
+	}
+
 }
 
 record NamedContextNode(ContextNode parent, Object object, String name) implements ContextNode {
@@ -284,4 +411,42 @@ record IndexedContextNode(ContextNode parent, Object object, int index) implemen
 	public String toString() {
 		return renderString();
 	}
+}
+
+record NonNullFunctionContextNode(Function<String, ?> object) implements NonNullContextNode {
+	@Override
+	public String toString() {
+		return renderString();
+	}
+
+	@Override
+	public @Nullable ContextNode get(String field) {
+		return ofChild(field, object().apply(field));
+	}
+
+}
+
+record NonNullNamedContextNode(ContextNode parent, Object object, String name) implements NonNullContextNode {
+	@Override
+	public String toString() {
+		return renderString();
+	}
+}
+
+record NonNullIndexedContextNode(ContextNode parent, Object object, int index) implements NonNullContextNode {
+	@Override
+	public String toString() {
+		return renderString();
+	}
+}
+
+enum EmptyContextNode implements ContextNode {
+
+	EMPTY;
+
+	@Override
+	public Object object() {
+		return Map.of();
+	}
+
 }

--- a/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextNode.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextNode.java
@@ -356,7 +356,6 @@ sealed interface Internal extends ContextNode {
 
 		}
 
-		@SuppressWarnings("null")
 		private static Stream<? extends @Nullable Object> arrayToStream(Object o) {
 
 			if (o instanceof int[] a) {

--- a/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextSupplier.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextSupplier.java
@@ -1,0 +1,23 @@
+package io.jstach.jstachio.context;
+
+/**
+ * A marker interface to signify something is context aware. If JStachio finds either the
+ * model or output to implement this interface it will be bound to the context with the
+ * name {@value #CONTEXT_BINDING_NAME}.
+ *
+ * @author agentgt
+ */
+public interface ContextSupplier {
+
+	/**
+	 * The default binding name for context.
+	 */
+	public static final String CONTEXT_BINDING_NAME = "@context";
+
+	/**
+	 * A context node never null but maybe {@linkplain ContextNode#empty() empty}.
+	 * @return context node.
+	 */
+	public ContextNode context();
+
+}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextSupplier.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextSupplier.java
@@ -3,16 +3,11 @@ package io.jstach.jstachio.context;
 /**
  * A marker interface to signify something is context aware. If JStachio finds either the
  * model or output to implement this interface it will be bound to the context with the
- * name {@value #CONTEXT_BINDING_NAME}.
+ * name {@value ContextNode#CONTEXT_BINDING_NAME}.
  *
  * @author agentgt
  */
 public interface ContextSupplier {
-
-	/**
-	 * The default binding name for context.
-	 */
-	public static final String CONTEXT_BINDING_NAME = "@context";
 
 	/**
 	 * A context node never null but maybe {@linkplain ContextNode#empty() empty}.

--- a/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextTemplate.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextTemplate.java
@@ -1,6 +1,7 @@
 package io.jstach.jstachio.context;
 
 import io.jstach.jstache.JStacheConfig;
+import io.jstach.jstachio.Output;
 
 /**
  * A context aware template.
@@ -8,6 +9,24 @@ import io.jstach.jstache.JStacheConfig;
  * @param <T> model type
  */
 public interface ContextTemplate<T> {
+
+	/**
+	 * Renders the passed in model to an appendable like output.
+	 * @param <A> output type
+	 * @param <E> error type
+	 * @param model a model assumed never to be <code>null</code>.
+	 * @param context context node.
+	 * @param appendable the appendable to write to.
+	 * @return the passed in appendable for convenience
+	 * @throws E if there is an error writing to the output
+	 * @apiNote if the eventual output is to be bytes use
+	 * {@link #write(Object, ContextNode, io.jstach.jstachio.Output.EncodedOutput)} as it
+	 * will leverage pre-encoding if the template has it.
+	 */
+	public <A extends Output<E>, E extends Exception> A execute( //
+			T model, //
+			ContextNode context, //
+			A appendable) throws E;
 
 	/**
 	 * Renders the passed in model directly to a binary stream leveraging pre-encoded
@@ -25,6 +44,7 @@ public interface ContextTemplate<T> {
 	 */
 	public <A extends io.jstach.jstachio.Output.EncodedOutput<E>, E extends Exception> A write( //
 			T model, //
-			ContextNode context, A output) throws E;
+			ContextNode context, //
+			A output) throws E;
 
 }

--- a/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextTemplate.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/context/ContextTemplate.java
@@ -1,0 +1,30 @@
+package io.jstach.jstachio.context;
+
+import io.jstach.jstache.JStacheConfig;
+
+/**
+ * A context aware template.
+ *
+ * @param <T> model type
+ */
+public interface ContextTemplate<T> {
+
+	/**
+	 * Renders the passed in model directly to a binary stream leveraging pre-encoded
+	 * parts of the template. This <em>may</em> improve performance when rendering UTF-8
+	 * to an OutputStream as some of the encoding is done in advance. Because the encoding
+	 * is done statically you cannot pass the charset in. The chosen charset comes from
+	 * {@link JStacheConfig#charset()}.
+	 * @param <A> output type
+	 * @param <E> error type
+	 * @param model a model assumed never to be <code>null</code>.
+	 * @param context context node.
+	 * @param output to write to.
+	 * @return the passed in output for convenience
+	 * @throws E if an error occurs while writing to output
+	 */
+	public <A extends io.jstach.jstachio.Output.EncodedOutput<E>, E extends Exception> A write( //
+			T model, //
+			ContextNode context, A output) throws E;
+
+}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/context/ObjectContext.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/context/ObjectContext.java
@@ -1,18 +1,24 @@
 package io.jstach.jstachio.context;
 
 import java.util.Iterator;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.Nullable;
 
+import io.jstach.jstache.JStache;
 import io.jstach.jstachio.context.Internal.ObjectContextNode;
 
 /**
- * Extend this class to make a model more like JSON/Map
+ * Extend this class to make {@link JStache} model act like JSON object or a
+ * java.util.Map.
+ *
+ * @see ContextNode
+ * @author agentgt
  */
 public non-sealed abstract class ObjectContext implements ObjectContextNode {
 
 	/**
-	 * Get value like map.
+	 * Get a value by key. This is analagous to {@link Map#get(Object)}.
 	 * @param key not null
 	 * @return value mapped to key.
 	 */
@@ -43,6 +49,11 @@ public non-sealed abstract class ObjectContext implements ObjectContextNode {
 	@Override
 	public final Iterator<@Nullable ContextNode> iterator() {
 		return ObjectContextNode.super.iterator();
+	}
+
+	@Override
+	public final boolean isFalsey() {
+		return ObjectContextNode.super.isFalsey();
 	}
 
 }

--- a/api/jstachio/src/main/java/io/jstach/jstachio/context/ObjectContext.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/context/ObjectContext.java
@@ -1,0 +1,48 @@
+package io.jstach.jstachio.context;
+
+import java.util.Iterator;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+import io.jstach.jstachio.context.Internal.ObjectContextNode;
+
+/**
+ * Extend this class to make a model more like JSON/Map
+ */
+public non-sealed abstract class ObjectContext implements ObjectContextNode {
+
+	/**
+	 * Get value like map.
+	 * @param key not null
+	 * @return value mapped to key.
+	 */
+	@Override
+	public abstract @Nullable Object getValue(String key);
+
+	@Override
+	public final Object object() {
+		return this;
+	}
+
+	@Override
+	public final @Nullable ContextNode get(String field) {
+		return ObjectContextNode.super.get(field);
+	}
+
+	@Override
+	public final @Nullable ContextNode find(String field) {
+		return ObjectContextNode.super.find(field);
+	}
+
+	@Override
+	public final @Nullable ContextNode parent() {
+		return null;
+	}
+
+	@SuppressWarnings("exports")
+	@Override
+	public final Iterator<@Nullable ContextNode> iterator() {
+		return ObjectContextNode.super.iterator();
+	}
+
+}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/formatters/DefaultFormatter.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/formatters/DefaultFormatter.java
@@ -10,7 +10,6 @@ import io.jstach.jstache.JStacheFormatterTypes;
 import io.jstach.jstachio.Appender;
 import io.jstach.jstachio.Formatter;
 import io.jstach.jstachio.Output;
-import io.jstach.jstachio.context.ContextNode;
 
 /**
  * Default formatters.
@@ -31,9 +30,6 @@ public interface DefaultFormatter extends Formatter {
 			@Nullable Object o) throws E {
 		if (o == null) {
 			throw new NullPointerException("null at: '" + path + "'");
-		}
-		else if (o instanceof ContextNode m) {
-			downstream.append(a, m.renderString());
 		}
 		else {
 			downstream.append(a, String.valueOf(o));

--- a/api/jstachio/src/main/java/io/jstach/jstachio/formatters/SpecFormatter.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/formatters/SpecFormatter.java
@@ -10,7 +10,6 @@ import io.jstach.jstache.JStacheFormatterTypes;
 import io.jstach.jstachio.Appender;
 import io.jstach.jstachio.Formatter;
 import io.jstach.jstachio.Output;
-import io.jstach.jstachio.context.ContextNode;
 
 /**
  * Formatter that follows the spec rules that if a variable is <code>null</code> it will
@@ -26,10 +25,7 @@ public interface SpecFormatter extends Formatter {
 	@Override
 	default <A extends Output<E>, E extends Exception> void format(Appender downstream, A a, String path, Class<?> c,
 			@Nullable Object o) throws E {
-		if (o instanceof ContextNode m) {
-			downstream.append(a, m.renderString());
-		}
-		else if (o != null) {
+		if (o != null) {
 			downstream.append(a, String.valueOf(o));
 		}
 	}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/formatters/package-info.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/formatters/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Builtin Formatters.
  */
+@org.eclipse.jdt.annotation.NonNullByDefault
 package io.jstach.jstachio.formatters;

--- a/api/jstachio/src/main/java/io/jstach/jstachio/output/BufferedReadableByteChannel.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/output/BufferedReadableByteChannel.java
@@ -103,7 +103,7 @@ interface BufferedReadableByteChannel extends ReadableByteChannel {
 	}
 
 	static BufferedReadableByteChannel of(BufferedEncodedOutput output, final Iterator<byte[]> arrays) {
-		Supplier<@Nullable byte[]> sup = () -> {
+		Supplier<byte @Nullable[]> sup = () -> {
 			if (!arrays.hasNext()) {
 				return null;
 			}
@@ -112,7 +112,7 @@ interface BufferedReadableByteChannel extends ReadableByteChannel {
 		return of(output, sup);
 	}
 
-	static BufferedReadableByteChannel of(BufferedEncodedOutput output, final Supplier<@Nullable byte[]> arrays) {
+	static BufferedReadableByteChannel of(BufferedEncodedOutput output, final Supplier<byte @Nullable []> arrays) {
 		int length = output.size();
 
 		return new BufferedReadableByteChannel() {
@@ -121,7 +121,7 @@ interface BufferedReadableByteChannel extends ReadableByteChannel {
 
 			private int chunkOffset = 0;
 
-			byte[] current = arrays.get();
+			byte @Nullable [] current = arrays.get();
 
 			@Override
 			public int read(ByteBuffer dst) {
@@ -131,9 +131,9 @@ interface BufferedReadableByteChannel extends ReadableByteChannel {
 
 				int readBytes = 0;
 
-				while (current != null && dst.hasRemaining()) {
+				byte[] chunk;
+				while ((chunk = current) != null && dst.hasRemaining()) {
 
-					byte[] chunk = current;
 					int chunkLength = chunk.length - chunkOffset;
 
 					// number of bytes capable of being read

--- a/api/jstachio/src/main/java/io/jstach/jstachio/output/BufferedReadableByteChannel.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/output/BufferedReadableByteChannel.java
@@ -103,7 +103,7 @@ interface BufferedReadableByteChannel extends ReadableByteChannel {
 	}
 
 	static BufferedReadableByteChannel of(BufferedEncodedOutput output, final Iterator<byte[]> arrays) {
-		Supplier<byte @Nullable[]> sup = () -> {
+		Supplier<byte @Nullable []> sup = () -> {
 			if (!arrays.hasNext()) {
 				return null;
 			}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/output/ContextAwareOutput.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/output/ContextAwareOutput.java
@@ -1,0 +1,122 @@
+package io.jstach.jstachio.output;
+
+import io.jstach.jstachio.Output;
+import io.jstach.jstachio.Output.EncodedOutput;
+import io.jstach.jstachio.context.ContextNode;
+import io.jstach.jstachio.context.ContextSupplier;
+
+/**
+ * Decorate outputs with a context.
+ *
+ * @author agentgt
+ */
+public sealed interface ContextAwareOutput<O> extends ContextSupplier {
+
+	/**
+	 * The original output
+	 * @return the original output
+	 */
+	public O getOutput();
+
+	/**
+	 * Wrap an output with a context.
+	 * @param <E> exception type
+	 * @param <O> output type
+	 * @param output output to wrap
+	 * @param context context to use
+	 * @return decorated output
+	 */
+	public static <E extends Exception, O extends Output<E>> ContextOutput<E, O> of(O output, ContextNode context) {
+		return new ContextOutput<>(output, context);
+	}
+
+	/**
+	 * Wrap an encoded output with a context.
+	 * @param <E> exception type
+	 * @param <O> output type
+	 * @param output output to wrap
+	 * @param context context to use
+	 * @return decorated output
+	 */
+	public static <E extends Exception, O extends EncodedOutput<E>> ContextEncodedOutput<E, O> of(O output,
+			ContextNode context) {
+		return new ContextEncodedOutput<>(output, context);
+	}
+
+	/**
+	 * A decorated output containing a context.
+	 *
+	 * @param <E> exception type
+	 * @param <O> output type
+	 */
+	public final class ContextOutput<E extends Exception, O extends Output<E>> extends ForwardingOutput<E>
+			implements ContextAwareOutput<O> {
+
+		private final O output;
+
+		private final ContextNode context;
+
+		private ContextOutput(O output, ContextNode context) {
+			super();
+			this.output = output;
+			this.context = context;
+		}
+
+		@Override
+		public ContextNode context() {
+			return this.context;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		protected O delegate() {
+			return this.output;
+		}
+
+		public O getOutput() {
+			return output;
+		}
+
+	}
+
+	/**
+	 * A decorated output containing a context.
+	 *
+	 * @param <E> exception type
+	 * @param <O> output type
+	 */
+	public final class ContextEncodedOutput<E extends Exception, O extends EncodedOutput<E>>
+			extends ForwardingEncodedOutput<E> implements ContextAwareOutput<O> {
+
+		private final O output;
+
+		private final ContextNode context;
+
+		private ContextEncodedOutput(O output, ContextNode context) {
+			super();
+			this.output = output;
+			this.context = context;
+		}
+
+		@Override
+		public ContextNode context() {
+			return this.context;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		protected O delegate() {
+			return this.output;
+		}
+
+		public O getOutput() {
+			return output;
+		}
+
+	}
+
+}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/output/ForwardingEncodedOutput.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/output/ForwardingEncodedOutput.java
@@ -1,0 +1,32 @@
+package io.jstach.jstachio.output;
+
+import java.nio.charset.Charset;
+
+import io.jstach.jstachio.Output.EncodedOutput;
+
+/**
+ * An encoded output that forwards all calls to a delegate.
+ *
+ * @param <E> error throw on any append or write
+ */
+abstract class ForwardingEncodedOutput<E extends Exception> extends ForwardingOutput<E> implements EncodedOutput<E> {
+
+	@Override
+	public void write(byte[] bytes) throws E {
+		delegate().write(bytes);
+	}
+
+	@Override
+	public void write(byte[] bytes, int off, int len) throws E {
+		delegate().write(bytes, off, len);
+	}
+
+	@Override
+	public Charset charset() {
+		return delegate().charset();
+	}
+
+	@Override
+	protected abstract EncodedOutput<E> delegate();
+
+}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/output/ForwardingEncodedOutput.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/output/ForwardingEncodedOutput.java
@@ -9,7 +9,8 @@ import io.jstach.jstachio.Output.EncodedOutput;
  *
  * @param <E> error throw on any append or write
  */
-abstract class ForwardingEncodedOutput<E extends Exception> extends ForwardingOutput<E> implements EncodedOutput<E> {
+public abstract class ForwardingEncodedOutput<E extends Exception> extends ForwardingOutput<E>
+		implements EncodedOutput<E> {
 
 	@Override
 	public void write(byte[] bytes) throws E {

--- a/api/jstachio/src/main/java/io/jstach/jstachio/output/ForwardingOutput.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/output/ForwardingOutput.java
@@ -1,0 +1,68 @@
+package io.jstach.jstachio.output;
+
+import io.jstach.jstachio.Output;
+
+/**
+ * An encoded output that forwards all calls to a delegate.
+ *
+ * @param <E> error throw on any append or write
+ */
+abstract class ForwardingOutput<E extends Exception> implements Output<E> {
+
+	/**
+	 * The output to forward to.
+	 * @return output to forward to.
+	 */
+	protected abstract Output<E> delegate();
+
+	@Override
+	public void append(CharSequence s) throws E {
+		delegate().append(s);
+	}
+
+	@Override
+	public void append(short s) throws E {
+		delegate().append(s);
+	}
+
+	@Override
+	public void append(int i) throws E {
+		delegate().append(i);
+	}
+
+	@Override
+	public void append(long l) throws E {
+		delegate().append(l);
+	}
+
+	@Override
+	public void append(double d) throws E {
+		delegate().append(d);
+	}
+
+	@Override
+	public void append(boolean b) throws E {
+		delegate().append(b);
+	}
+
+	@Override
+	public Appendable toAppendable() {
+		return delegate().toAppendable();
+	}
+
+	@Override
+	public void append(char c) throws E {
+		delegate().append(c);
+	}
+
+	@Override
+	public void append(String s) throws E {
+		delegate().append(s);
+	}
+
+	@Override
+	public void append(CharSequence csq, int start, int end) throws E {
+		delegate().append(csq, start, end);
+	}
+
+}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/output/ForwardingOutput.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/output/ForwardingOutput.java
@@ -7,7 +7,7 @@ import io.jstach.jstachio.Output;
  *
  * @param <E> error throw on any append or write
  */
-abstract class ForwardingOutput<E extends Exception> implements Output<E> {
+public abstract class ForwardingOutput<E extends Exception> implements Output<E> {
 
 	/**
 	 * The output to forward to.

--- a/api/jstachio/src/main/java/io/jstach/jstachio/output/LimitEncodedOutput.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/output/LimitEncodedOutput.java
@@ -118,7 +118,7 @@ abstract non-sealed class AbstractLimitEncodedOutput implements LimitEncodedOutp
 	}
 
 	@Override
-	public OutputStream consumer() {
+	public @Nullable OutputStream consumer() {
 		return consumer;
 	}
 
@@ -179,7 +179,7 @@ abstract non-sealed class AbstractLimitEncodedOutput implements LimitEncodedOutp
 		var c = this.consumer;
 		if (c == null) {
 			this.consumer = c = createConsumer(size);
-			this.buffer.transferTo(consumer);
+			this.buffer.transferTo(c);
 		}
 		close(c);
 		this.consumer = null;

--- a/api/jstachio/src/main/java/io/jstach/jstachio/output/ThresholdEncodedOutput.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/output/ThresholdEncodedOutput.java
@@ -5,6 +5,7 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -133,6 +134,7 @@ public abstract non-sealed class ThresholdEncodedOutput<T, E extends Exception> 
 
 	private void addChunk(byte[] chunk) throws E {
 		int length = chunk.length;
+		@Nullable
 		T c = this.consumer;
 		if (c != null) {
 			write(c, chunk);
@@ -141,9 +143,9 @@ public abstract non-sealed class ThresholdEncodedOutput<T, E extends Exception> 
 			/*
 			 * We have exceeded the threshold
 			 */
-			c = this.consumer = createConsumer(-1);
+			this.consumer = c = Objects.requireNonNull(createConsumer(-1));
 			chunks.add(chunk);
-			drain(consumer);
+			drain(c);
 		}
 		else {
 			chunks.add(chunk);
@@ -175,9 +177,10 @@ public abstract non-sealed class ThresholdEncodedOutput<T, E extends Exception> 
 	 */
 	@Override
 	public void close() throws E {
-		var c = this.consumer;
+		@Nullable
+		T c = this.consumer;
 		if (c == null) {
-			this.consumer = c = createConsumer(size);
+			this.consumer = c = Objects.requireNonNull(createConsumer(size));
 			drain(c);
 		}
 		close(c);

--- a/api/jstachio/src/main/java/io/jstach/jstachio/output/package-info.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/output/package-info.java
@@ -66,4 +66,5 @@
  * @see io.jstach.jstachio.output.ThresholdEncodedOutput
  * @apiNote As with most IO the classes in this package are not thread safe unless noted.
  */
+@org.eclipse.jdt.annotation.NonNullByDefault
 package io.jstach.jstachio.output;

--- a/api/jstachio/src/main/java/io/jstach/jstachio/spi/AbstractJStachio.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/spi/AbstractJStachio.java
@@ -6,6 +6,9 @@ import static io.jstach.jstachio.spi.Templates.validateEncoding;
 import io.jstach.jstachio.JStachio;
 import io.jstach.jstachio.Output;
 import io.jstach.jstachio.Output.EncodedOutput;
+import io.jstach.jstachio.context.ContextJStachio;
+import io.jstach.jstachio.context.ContextNode;
+import io.jstach.jstachio.context.ContextTemplate;
 import io.jstach.jstachio.Template;
 import io.jstach.jstachio.TemplateInfo;
 import io.jstach.jstachio.TemplateModel;
@@ -19,7 +22,7 @@ import io.jstach.jstachio.spi.JStachioFilter.FilterChain;
  * @see JStachioExtensions
  * @author agentgt
  */
-public abstract class AbstractJStachio implements JStachio, JStachioExtensions.Provider {
+public abstract class AbstractJStachio implements JStachio, JStachioExtensions.Provider, ContextJStachio {
 
 	/**
 	 * Do nothing constructor
@@ -39,6 +42,37 @@ public abstract class AbstractJStachio implements JStachio, JStachioExtensions.P
 		var t = _findTemplate(model);
 		validateEncoding(t, appendable);
 		return t.write(model, appendable);
+	}
+
+	/*
+	 * IF YOU want this method to be not final please file a bug.
+	 */
+	@SuppressWarnings({ "unchecked" })
+	@Override
+	public final <A extends EncodedOutput<E>, E extends Exception> A write(Object model, ContextNode context, A output)
+			throws E {
+		var t = _findTemplate(model);
+		validateEncoding(t, output);
+		if (t instanceof ContextTemplate ct) {
+			var _ct = (ContextTemplate<Object>) ct;
+			return _ct.write(model, context, output);
+		}
+		return t.write(model, output);
+	}
+
+	/*
+	 * IF YOU want this method to be not final please file a bug.
+	 */
+	@SuppressWarnings({ "unchecked" })
+	@Override
+	public final <A extends Output<E>, E extends Exception> A execute(Object model, ContextNode context, A appendable)
+			throws E {
+		var t = _findTemplate(model);
+		if (t instanceof ContextTemplate ct) {
+			var _ct = (ContextTemplate<Object>) ct;
+			return _ct.execute(model, context, appendable);
+		}
+		return t.execute(model, appendable);
 	}
 
 	/*

--- a/api/jstachio/src/main/java/io/jstach/jstachio/spi/AbstractJStachio.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/spi/AbstractJStachio.java
@@ -66,7 +66,7 @@ public abstract class AbstractJStachio implements JStachio, JStachioExtensions.P
 		}
 		var filter = loadFilter(model, template);
 		Template t = FilterChain.toTemplate(filter, template);
-		return t;
+		return (Template<Object>) t;
 	}
 
 	/**

--- a/api/jstachio/src/main/java/io/jstach/jstachio/spi/JStachioConfig.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/spi/JStachioConfig.java
@@ -2,6 +2,7 @@ package io.jstach.jstachio.spi;
 
 import java.lang.System.Logger;
 import java.util.List;
+import java.util.Objects;
 import java.util.ResourceBundle;
 
 import org.eclipse.jdt.annotation.NonNull;
@@ -103,14 +104,14 @@ public non-sealed interface JStachioConfig extends JStachioExtension {
 	 * @throws NullPointerException if the fallback is null or if the key is null.
 	 */
 	default String requireProperty(String key, String fallback) {
-		if (key == null) {
+		if (Objects.isNull(key)) {
 			throw new NullPointerException("key is null");
 		}
 		String v = getProperty(key);
 		if (v == null) {
 			v = fallback;
 		}
-		if (v == null) {
+		if (Objects.isNull(v)) {
 			throw new NullPointerException("fallback is null. key: " + key);
 		}
 		return v;
@@ -168,8 +169,7 @@ enum NOOPLogger implements Logger {
 	}
 
 	@Override
-	public void log(Level level, @Nullable ResourceBundle bundle, @Nullable String msg,
-			@Nullable Throwable thrown) {
+	public void log(Level level, @Nullable ResourceBundle bundle, @Nullable String msg, @Nullable Throwable thrown) {
 
 	}
 

--- a/api/jstachio/src/main/java/io/jstach/jstachio/spi/JStachioConfig.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/spi/JStachioConfig.java
@@ -170,13 +170,13 @@ enum NOOPLogger implements Logger {
 
 	@Override
 	public void log(Level level, @Nullable ResourceBundle bundle, @Nullable String msg, @Nullable Throwable thrown) {
-
+		// Do nothing
 	}
 
 	@Override
 	public void log(Level level, @Nullable ResourceBundle bundle, @Nullable String format,
 			@Nullable Object @NonNull... params) {
-
+		// Do nothing
 	}
 
 }

--- a/api/jstachio/src/main/java/io/jstach/jstachio/spi/JStachioConfig.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/spi/JStachioConfig.java
@@ -163,18 +163,18 @@ enum NOOPLogger implements Logger {
 	}
 
 	@Override
-	public boolean isLoggable(@NonNull Level level) {
+	public boolean isLoggable(Level level) {
 		return false;
 	}
 
 	@Override
-	public void log(@NonNull Level level, @Nullable ResourceBundle bundle, @Nullable String msg,
+	public void log(Level level, @Nullable ResourceBundle bundle, @Nullable String msg,
 			@Nullable Throwable thrown) {
 
 	}
 
 	@Override
-	public void log(@NonNull Level level, @Nullable ResourceBundle bundle, @Nullable String format,
+	public void log(Level level, @Nullable ResourceBundle bundle, @Nullable String format,
 			@Nullable Object @NonNull... params) {
 
 	}

--- a/api/jstachio/src/main/java/io/jstach/jstachio/spi/JStachioFilter.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/spi/JStachioFilter.java
@@ -168,7 +168,7 @@ public non-sealed interface JStachioFilter extends JStachioExtension {
 			if (template instanceof FilterChain c) {
 				previous = c;
 			}
-			else if (template instanceof @SuppressWarnings("rawtypes") Template t) {
+			else if (template instanceof Template t) {
 				/*
 				 * This is sort of abusing that filter chains happen to be a functional
 				 * interface

--- a/api/jstachio/src/main/java/io/jstach/jstachio/spi/JStachioTemplateFinder.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/spi/JStachioTemplateFinder.java
@@ -296,7 +296,7 @@ final class ClassValueCacheTemplateFinder implements JStachioTemplateFinder {
 			@Override
 			protected @Nullable TemplateInfo computeValue(@Nullable Class<?> type) {
 				try {
-					return delegate.findTemplate(type);
+					return delegate.findTemplate(Objects.requireNonNull(type));
 				}
 				catch (Exception e) {
 					Templates.sneakyThrow(e);
@@ -308,7 +308,8 @@ final class ClassValueCacheTemplateFinder implements JStachioTemplateFinder {
 
 	@Override
 	public TemplateInfo findTemplate(Class<?> modelType) throws Exception {
-		return cache.get(modelType);
+		Objects.requireNonNull(modelType);
+		return Objects.requireNonNull(cache.get(modelType));
 	}
 
 	@Override

--- a/api/jstachio/src/main/java/io/jstach/jstachio/spi/Templates.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/spi/Templates.java
@@ -422,9 +422,9 @@ public final class Templates {
 		return s.filter(p -> p != null).map(p -> p.getAnnotation(annotationClass)).filter(a -> a != null);
 	}
 
-	private static @NonNull Stream<AnnotatedElement> annotationElements(Class<?> c) {
-		Stream<? extends AnnotatedElement> enclosing = enclosing(c).flatMap(Templates::expandUsing);
-		var s = Stream.concat(enclosing, Stream.of(c.getPackage(), c.getModule()));
+	private static Stream<? extends @Nullable AnnotatedElement> annotationElements(Class<?> c) {
+		Stream<? extends @Nullable AnnotatedElement> enclosing = enclosing(c).flatMap(Templates::expandUsing);
+		var s = Stream.concat(enclosing, Stream.<AnnotatedElement>of(c.getPackage(), c.getModule()));
 		return s;
 	}
 

--- a/api/jstachio/src/main/java/io/jstach/jstachio/spi/Templates.java
+++ b/api/jstachio/src/main/java/io/jstach/jstachio/spi/Templates.java
@@ -388,7 +388,6 @@ public final class Templates {
 		String cname;
 		if (a == null || a.name().isBlank()) {
 
-			@SuppressWarnings("null") // Eclipse null analysis bug
 			JStacheName name = findAnnotations(modelClass, JStacheConfig.class) //
 					.flatMap(config -> Stream.of(config.naming())).findFirst().orElse(null);
 

--- a/api/jstachio/src/test/java/io/jstach/jstachio/context/ContextNodeTest.java
+++ b/api/jstachio/src/test/java/io/jstach/jstachio/context/ContextNodeTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 
 public class ContextNodeTest {
 
-	@SuppressWarnings({ "null", "deprecation" })
 	@Test
 	public void testIsFalseyArray() {
 		int[] ia = new int[] { 1, 0 };
@@ -19,11 +18,9 @@ public class ContextNodeTest {
 		assertFalse(ContextNode.ofRoot(ia).iterator().hasNext());
 	}
 
-	@SuppressWarnings("null")
 	@Test
 	public void testIteratorOnArray() throws Exception {
 		int[] ia = new int[] { 1, 0 };
-		@SuppressWarnings("deprecation")
 		var node = ContextNode.ofRoot(ia);
 		StringBuilder sb = new StringBuilder();
 		for (var n : node) {

--- a/api/jstachio/src/test/java/io/jstach/jstachio/context/ContextNodeTest.java
+++ b/api/jstachio/src/test/java/io/jstach/jstachio/context/ContextNodeTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 public class ContextNodeTest {
 
+	@SuppressWarnings({ "null", "deprecation" })
 	@Test
 	public void testIsFalseyArray() {
 		int[] ia = new int[] { 1, 0 };
@@ -18,9 +19,11 @@ public class ContextNodeTest {
 		assertFalse(ContextNode.ofRoot(ia).iterator().hasNext());
 	}
 
+	@SuppressWarnings("null")
 	@Test
 	public void testIteratorOnArray() throws Exception {
 		int[] ia = new int[] { 1, 0 };
+		@SuppressWarnings("deprecation")
 		var node = ContextNode.ofRoot(ia);
 		StringBuilder sb = new StringBuilder();
 		for (var n : node) {

--- a/compiler/apt/src/main/java/io/jstach/apt/GenerateRendererProcessor.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/GenerateRendererProcessor.java
@@ -60,7 +60,6 @@ import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;

--- a/compiler/apt/src/main/java/io/jstach/apt/TemplateClassWriter.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/TemplateClassWriter.java
@@ -485,6 +485,18 @@ class TemplateClassWriter implements LoggingSupplier {
 			println("");
 		}
 
+		if (jstachio && contextSupport) {
+			println("    @Override");
+			println("    public " + _A + " A execute(" //
+					+ idt + className + " model, " //
+					+ idt + _ContextNode + " context, " //
+					+ idt + "A" + " a) throws E {");
+			println("        render(this, model, context, a, " + templateFormatterExp + ", " + templateEscaperExp + ", "
+					+ templateAppenderExp + ");");
+			println("        return a;");
+			println("    }");
+			println("");
+		}
 		if (jstachio && preEncode && contextSupport) {
 			println("    @Override");
 			println("    public " + _EncodedOutput + " A write(" //
@@ -955,7 +967,6 @@ class TemplateClassWriter implements LoggingSupplier {
 				+ idt + _Escaper + " " + variables.escaper() + "," //
 				+ idt + _Appender + " " + variables.appender() + ") throws E {");
 
-		// printContextNode(variables, dataName, model);
 		TemplateCompilerContext context = codeWriter.createTemplateContext(model.namedTemplate(), element, dataName,
 				variables, model.flags());
 		codeWriter.compileTemplate(templateLoader, context, templateCompilerType);
@@ -969,17 +980,6 @@ class TemplateClassWriter implements LoggingSupplier {
 
 		codeWriter.setFormatCallType(formatCallType);
 
-	}
-
-	private void printContextNode(VariableContext variables, String dataName, RendererModel model) {
-		boolean enabled = model.flags().contains(Flag.CONTEXT_SUPPORT);
-		if (!enabled) {
-			println("        " + "@SuppressWarnings(\"unused\")");
-		}
-
-		String contextCreator = renderContextNode(variables, dataName, enabled);
-		String contextDeclare = _ContextNode + " " + variables.context() + " = " + contextCreator + ";";
-		println("        " + contextDeclare);
 	}
 
 	private static String renderContextNode(VariableContext variables, String dataName, RendererModel model) {

--- a/compiler/apt/src/main/java/io/jstach/apt/TemplateClassWriter.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/TemplateClassWriter.java
@@ -802,6 +802,9 @@ class TemplateClassWriter implements LoggingSupplier {
 					+ idt + _Formatter + " " + variables.formatter() + "," //
 					+ idt + _Escaper + " " + variables.escaper() + ") throws java.io.IOException {");
 		}
+		if (jstachio) {
+			printContextNode(variables, dataName);
+		}
 		TemplateCompilerContext context = codeWriter.createTemplateContext(model.namedTemplate(), element, dataName,
 				variables, model.flags());
 		codeWriter.compileTemplate(templateLoader, context, templateCompilerType);
@@ -857,6 +860,8 @@ class TemplateClassWriter implements LoggingSupplier {
 				+ idt + _Formatter + " " + variables.formatter() + "," //
 				+ idt + _Escaper + " " + variables.escaper() + "," //
 				+ idt + _Appender + " " + variables.appender() + ") throws E {");
+
+		printContextNode(variables, dataName);
 		TemplateCompilerContext context = codeWriter.createTemplateContext(model.namedTemplate(), element, dataName,
 				variables, model.flags());
 		codeWriter.compileTemplate(templateLoader, context, templateCompilerType);
@@ -870,6 +875,18 @@ class TemplateClassWriter implements LoggingSupplier {
 
 		codeWriter.setFormatCallType(formatCallType);
 
+	}
+
+	private void printContextNode(VariableContext variables, String dataName) {
+		println("        " + renderContextNode(variables, dataName));
+		println("        " + Prisms.CONTEXT_NODE_CLASS + ".suppressUnused(" + variables.context() + ");");
+	}
+
+	private static String renderContextNode(VariableContext variables, String dataName) {
+		String contextCreator = Prisms.CONTEXT_NODE_CLASS + ".resolve(" + dataName + "," + variables.unescapedWriter()
+				+ ")";
+		String contextDeclare = Prisms.CONTEXT_NODE_CLASS + " " + variables.context();
+		return contextDeclare + " = " + contextCreator + ";";
 	}
 
 	private static final Map<Charset, String> STANDARD_CHARSETS = Map.of( //

--- a/compiler/apt/src/main/java/io/jstach/apt/internal/context/ContextNodeRenderingContext.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/internal/context/ContextNodeRenderingContext.java
@@ -19,6 +19,17 @@ public class ContextNodeRenderingContext extends MapRenderingContext {
 	public @Nullable JavaExpression find(String name, Predicate<RenderingContext> filter) throws ContextException {
 		// See MapNode.find
 		// Currently this only works if MapNode is the root context
+
+		var parent = getParent();
+
+		JavaExpression r = parent.find(name, filter.and(c -> !(c instanceof MapRenderingContext)));
+		if (r != null) {
+			return r;
+		}
+		if (!filter.test(this)) {
+			return null;
+		}
+
 		var all = JavaLanguageModel.getInstance().getElements().getAllMembers(definitionElement);
 
 		var getMethod = ElementFilter.methodsIn(all).stream()

--- a/compiler/apt/src/main/java/io/jstach/apt/internal/context/IterableRenderingContext.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/internal/context/IterableRenderingContext.java
@@ -45,6 +45,7 @@ import io.jstach.apt.internal.util.ToStringTypeVisitor;
 
 /**
  * @author Victor Nazarov
+ * @author agentgt
  */
 class IterableRenderingContext implements RenderingContext {
 

--- a/compiler/apt/src/main/java/io/jstach/apt/internal/context/RenderingCodeGenerator.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/internal/context/RenderingCodeGenerator.java
@@ -45,6 +45,7 @@ import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.ElementFilter;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 import io.jstach.apt.internal.AnnotatedException;
 import io.jstach.apt.internal.FormatterTypes;
@@ -112,7 +113,7 @@ public class RenderingCodeGenerator {
 
 		KnownType knownType = javaModel.resolveType(type).orElse(null);
 
-		if (knownType != null && ((knownType instanceof NativeType) || knownType.equals(knownTypes._String))) {
+		if (isDirectFormat(type, knownType)) {
 			return renderFormatCall(variables, path, text);
 		}
 		else if (knownType != null && knownType instanceof ObjectType) {
@@ -129,6 +130,23 @@ public class RenderingCodeGenerator {
 
 		throw new TypeException(MessageFormat.format(
 				"Can''t render {0} expression of {1} type as it is not an allowed type to format. ", text, type));
+	}
+
+	private boolean isDirectFormat(TypeMirror type, @Nullable KnownType kt) {
+		KnownType formattableType = knownTypes._Formattable.orElse(null);
+		if (formattableType != null && formattableType.isSupertype(type)) {
+			return true;
+		}
+		if (kt == null) {
+			return false;
+		}
+		if (kt instanceof NativeType) {
+			return true;
+		}
+		if (kt.equals(knownTypes._String)) {
+			return true;
+		}
+		return false;
 	}
 
 	private String renderFormatCall(VariableContext variables, String path, String text, String cname) {

--- a/compiler/apt/src/main/java/io/jstach/apt/internal/context/RenderingCodeGenerator.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/internal/context/RenderingCodeGenerator.java
@@ -239,7 +239,7 @@ public class RenderingCodeGenerator {
 					yield createIterableContext(childType, expression, enclosing);
 				}
 				default: {
-					yield createMapNodeContext(expression, enclosing);
+					yield createContextNodeContext(expression, enclosing);
 				}
 			};
 		}
@@ -330,7 +330,7 @@ public class RenderingCodeGenerator {
 		return map;
 	}
 
-	private RenderingContext createMapNodeContext(JavaExpression expression, RenderingContext enclosing) {
+	private RenderingContext createContextNodeContext(JavaExpression expression, RenderingContext enclosing) {
 		RenderingContext nullable = nullableRenderingContext(expression, enclosing);
 		DeclaredType mapType = (DeclaredType) expression.type();
 		ContextNodeRenderingContext map = new ContextNodeRenderingContext(expression, javaModel.asElement(mapType),
@@ -349,7 +349,7 @@ public class RenderingCodeGenerator {
 		IterableRenderingContext iterable = new IterableRenderingContext(expression, elementVariableName,
 				indexVariableName, variables);
 		if (expression.model().isType(expression.type(), knownTypes._ContextNode)) {
-			return createMapNodeContext(iterable.elementExpession(), iterable);
+			return createContextNodeContext(iterable.elementExpession(), iterable);
 		}
 		return createRenderingContext(ContextType.SECTION_VAR, iterable.elementExpession(), iterable);
 	}

--- a/compiler/apt/src/main/java/io/jstach/apt/internal/context/RootRenderingContext.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/internal/context/RootRenderingContext.java
@@ -56,12 +56,24 @@ class RootRenderingContext implements RenderingContext {
 
 	@Override
 	public @Nullable JavaExpression get(String name) throws ContextException {
+		return _get(name);
+	}
+
+	private JavaExpression _get(String name) {
+		if (name.equals("@context")) {
+			var contextNodeType = JavaLanguageModel.getInstance().knownTypes()._ContextNode.orElse(null);
+			if (contextNodeType == null) {
+				return null;
+			}
+			return JavaLanguageModel.getInstance().expression(variables.context(),
+					contextNodeType.typeElement().asType());
+		}
 		return null;
 	}
 
 	@Override
 	public @Nullable JavaExpression find(String name, Predicate<RenderingContext> filter) {
-		return null;
+		return _get(name);
 	}
 
 	@Override

--- a/compiler/apt/src/main/java/io/jstach/apt/internal/context/VariableContext.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/internal/context/VariableContext.java
@@ -52,6 +52,8 @@ public class VariableContext {
 
 	public static String TEXT = "TEXT";
 
+	public static String CONTEXT = "_context";
+
 	public static VariableContext createDefaultContext(NullChecking nullChecking) {
 		TreeMap<String, Integer> variables = new TreeMap<>();
 		variables.put(ESCAPER, 1);
@@ -170,6 +172,10 @@ public class VariableContext {
 
 	public boolean isEscaped() {
 		return escaped;
+	}
+
+	public String context() {
+		return CONTEXT;
 	}
 
 	public NullChecking nullChecking() {

--- a/compiler/apt/src/main/java/io/jstach/apt/internal/context/VariableContext.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/internal/context/VariableContext.java
@@ -62,10 +62,9 @@ public class VariableContext {
 		variables.put(APPENDER, 1);
 		variables.put(APPENDABLE, 1);
 		variables.put(FORMATTER, 1);
+		variables.put(TEMPLATE, 1);
 		variables.put(CONTEXT, 1);
 
-		// return new VariableContext(APPENDER, ESCAPER, APPENDABLE, FORMATTER, variables,
-		// null, true, nullChecking);
 		return new RootVariableContext(APPENDER, ESCAPER, APPENDABLE, FORMATTER, TEMPLATE, CONTEXT, variables,
 				nullChecking);
 	}

--- a/compiler/apt/src/main/java/io/jstach/apt/internal/context/VariableContext.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/internal/context/VariableContext.java
@@ -50,9 +50,11 @@ public class VariableContext {
 
 	public static String FORMATTER = "formatter";
 
-	public static String TEXT = "TEXT";
+	public static String TEMPLATE = "template";
 
-	public static String CONTEXT = "_context";
+	public static String CONTEXT = "context";
+
+	public static String TEXT = "TEXT";
 
 	public static VariableContext createDefaultContext(NullChecking nullChecking) {
 		TreeMap<String, Integer> variables = new TreeMap<>();
@@ -60,9 +62,12 @@ public class VariableContext {
 		variables.put(APPENDER, 1);
 		variables.put(APPENDABLE, 1);
 		variables.put(FORMATTER, 1);
+		variables.put(CONTEXT, 1);
+
 		// return new VariableContext(APPENDER, ESCAPER, APPENDABLE, FORMATTER, variables,
 		// null, true, nullChecking);
-		return new RootVariableContext(APPENDER, ESCAPER, APPENDABLE, FORMATTER, variables, nullChecking);
+		return new RootVariableContext(APPENDER, ESCAPER, APPENDABLE, FORMATTER, TEMPLATE, CONTEXT, variables,
+				nullChecking);
 	}
 
 	private final String appender;
@@ -72,6 +77,10 @@ public class VariableContext {
 	private final String unescapedWriter;
 
 	private final String formatter;
+
+	private final String template;
+
+	private final String context;
 
 	private final Map<String, Integer> variables;
 
@@ -102,13 +111,15 @@ public class VariableContext {
 
 	}
 
-	VariableContext(String appender, String escaper, String unescapedWriter, String formatter,
-			Map<String, Integer> variables, @Nullable VariableContext parent, boolean escaped,
+	VariableContext(String appender, String escaper, String unescapedWriter, String formatter, String template,
+			String context, Map<String, Integer> variables, @Nullable VariableContext parent, boolean escaped,
 			NullChecking nullChecking) {
 		this.appender = appender;
 		this.escaper = escaper;
 		this.unescapedWriter = unescapedWriter;
 		this.formatter = formatter;
+		this.template = template;
+		this.context = context;
 		this.variables = variables;
 		this.parent = parent;
 		this.escaped = escaped;
@@ -119,9 +130,10 @@ public class VariableContext {
 
 		private List<String> textCodes = new ArrayList<>();
 
-		RootVariableContext(String appender, String escaper, String unescapedWriter, String formatter,
-				Map<String, Integer> variables, NullChecking nullChecking) {
-			super(appender, escaper, unescapedWriter, formatter, variables, null, true, nullChecking);
+		RootVariableContext(String appender, String escaper, String unescapedWriter, String formatter, String template,
+				String context, Map<String, Integer> variables, NullChecking nullChecking) {
+			super(appender, escaper, unescapedWriter, formatter, template, context, variables, null, true,
+					nullChecking);
 		}
 
 	}
@@ -175,7 +187,11 @@ public class VariableContext {
 	}
 
 	public String context() {
-		return CONTEXT;
+		return context;
+	}
+
+	public String template() {
+		return template;
 	}
 
 	public NullChecking nullChecking() {
@@ -183,8 +199,8 @@ public class VariableContext {
 	}
 
 	VariableContext unescaped() {
-		return new VariableContext(appender, appender, unescapedWriter, formatter, variables, parent, false,
-				nullChecking);
+		return new VariableContext(appender, appender, unescapedWriter, formatter, template, context, variables, parent,
+				false, nullChecking);
 	}
 
 	private @Nullable Integer lookupVariable(String baseName) {
@@ -223,8 +239,8 @@ public class VariableContext {
 	}
 
 	VariableContext createEnclosedContext() {
-		return new VariableContext(appender, escaper, unescapedWriter, formatter, new TreeMap<String, Integer>(), this,
-				true, nullChecking);
+		return new VariableContext(appender, escaper, unescapedWriter, formatter, template, context,
+				new TreeMap<String, Integer>(), this, true, nullChecking);
 	}
 
 }

--- a/compiler/apt/src/main/java/io/jstach/apt/internal/context/types/KnownTypes.java
+++ b/compiler/apt/src/main/java/io/jstach/apt/internal/context/types/KnownTypes.java
@@ -104,6 +104,8 @@ public class KnownTypes implements TypesMixin {
 
 	public final Optional<ObjectType> _ContextNode;
 
+	public final Optional<ObjectType> _Formattable;
+
 	public final ObjectType _UUID;
 
 	public final ObjectType _URI;
@@ -150,6 +152,7 @@ public class KnownTypes implements TypesMixin {
 		_Optional = b.objectType(Optional.class);
 		_ContextNode = b.optionalObjectType(Prisms.CONTEXT_NODE_CLASS); // MapNode needs
 																		// to be above
+		_Formattable = b.optionalObjectType(Prisms.FORMATTABLE_CLASS);
 		// _Iterable
 		_Iterable = b.objectType(Iterable.class);
 		_List = b.objectType(List.class);

--- a/compiler/jstachio-prisms/src/main/java/io/jstach/apt/prism/Prisms.java
+++ b/compiler/jstachio-prisms/src/main/java/io/jstach/apt/prism/Prisms.java
@@ -73,6 +73,11 @@ public interface Prisms {
 	/**
 	 * Generated
 	 */
+	public static final String JSTACHE_FLAGS_CONTEXT_SUPPORT = "jstache.context_support";
+
+	/**
+	 * Generated
+	 */
 	@NonNullByDefault
 	public enum Flag {
 
@@ -96,6 +101,10 @@ public interface Prisms {
 		 * Generated
 		 */
 		PRE_ENCODE_DISABLE, //
+		/**
+		 * Generated
+		 */
+		CONTEXT_SUPPORT, //
 
 	}
 
@@ -191,6 +200,11 @@ public interface Prisms {
 	/**
 	 * Generated
 	 */
+	public static final String FORMATTABLE_CLASS = "io.jstach.jstachio.Formatter.Formattable";
+
+	/**
+	 * Generated
+	 */
 	public static final String DEFAULT_FORMATTER_CLASS = "io.jstach.jstachio.formatters.DefaultFormatter";
 
 	/**
@@ -217,6 +231,11 @@ public interface Prisms {
 	 * Generated
 	 */
 	public static final String CONTEXT_NODE_CLASS = "io.jstach.jstachio.context.ContextNode";
+
+	/**
+	 * Generated
+	 */
+	public static final String CONTEXT_TEMPLATE_CLASS = "io.jstach.jstachio.context.ContextTemplate";
 
 	/**
 	 * Generated

--- a/compiler/jstachio-prisms/src/test/java/io/jstach/apt/prism/PrismsTest.java
+++ b/compiler/jstachio-prisms/src/test/java/io/jstach/apt/prism/PrismsTest.java
@@ -27,6 +27,7 @@ import io.jstach.jstachio.Template;
 import io.jstach.jstachio.TemplateConfig;
 import io.jstach.jstachio.TemplateInfo;
 import io.jstach.jstachio.context.ContextNode;
+import io.jstach.jstachio.context.ContextTemplate;
 import io.jstach.jstachio.escapers.Html;
 import io.jstach.jstachio.escapers.PlainText;
 import io.jstach.jstachio.formatters.DefaultFormatter;
@@ -222,12 +223,14 @@ public class PrismsTest {
 				Appender.class, //
 				Escaper.class, //
 				Formatter.class, //
+				Formatter.Formattable.class, //
 				DefaultFormatter.class, //
 				TemplateInfo.class, //
 				TemplateConfig.class, //
 				FilterChain.class, //
 				JStachioExtension.class, //
 				ContextNode.class, //
+				ContextTemplate.class, //
 				UnspecifiedFormatter.class, //
 				UnspecifiedContentType.class, //
 				Html.class, //

--- a/etc/eea/java/io/OutputStream.eea
+++ b/etc/eea/java/io/OutputStream.eea
@@ -2,3 +2,9 @@ class java/io/OutputStream
 nullOutputStream
  ()Ljava/io/OutputStream;
  ()L1java/io/OutputStream;
+write
+ ([B)V
+ ([1B)V
+write
+ ([BII)V
+ ([1BII)V

--- a/etc/eea/java/nio/channels/ReadableByteChannel.eea
+++ b/etc/eea/java/nio/channels/ReadableByteChannel.eea
@@ -1,0 +1,4 @@
+class java/nio/channels/ReadableByteChannel
+read
+ (Ljava/nio/ByteBuffer;)I
+ (L1java/nio/ByteBuffer;)I

--- a/etc/eea/java/util/Comparator.eea
+++ b/etc/eea/java/util/Comparator.eea
@@ -2,6 +2,9 @@ class java/util/Comparator
 comparing
  <T:Ljava/lang/Object;U::Ljava/lang/Comparable<-TU;>;>(Ljava/util/function/Function<-TT;+TU;>;)Ljava/util/Comparator<TT;>;
  <T:Ljava/lang/Object;U::Ljava/lang/Comparable<-TU;>;>(Ljava/util/function/Function<-TT;+TU;>;)L1java/util/Comparator<TT;>;
+comparingInt
+ <T:Ljava/lang/Object;>(Ljava/util/function/ToIntFunction<-TT;>;)Ljava/util/Comparator<TT;>;
+ <T:Ljava/lang/Object;>(Ljava/util/function/ToIntFunction<-TT;>;)L1java/util/Comparator<TT;>;
 reverseOrder
  <T::Ljava/lang/Comparable<-TT;>;>()Ljava/util/Comparator<TT;>;
  <T::Ljava/lang/Comparable<-TT;>;>()L1java/util/Comparator<TT;>;

--- a/etc/eea/java/util/ServiceLoader$Provider.eea
+++ b/etc/eea/java/util/ServiceLoader$Provider.eea
@@ -1,0 +1,4 @@
+class java/util/ServiceLoader$Provider
+get
+ ()TS;
+ ()T1S;

--- a/etc/eea/java/util/ServiceLoader.eea
+++ b/etc/eea/java/util/ServiceLoader.eea
@@ -2,3 +2,6 @@ class java/util/ServiceLoader
 load
  <S:Ljava/lang/Object;>(Ljava/lang/Class<TS;>;)Ljava/util/ServiceLoader<TS;>;
  <S:Ljava/lang/Object;>(Ljava/lang/Class<TS;>;)L1java/util/ServiceLoader<TS;>;
+load
+ <S:Ljava/lang/Object;>(Ljava/lang/Class<TS;>;Ljava/lang/ClassLoader;)Ljava/util/ServiceLoader<TS;>;
+ <S:Ljava/lang/Object;>(Ljava/lang/Class<TS;>;Ljava/lang/ClassLoader;)L1java/util/ServiceLoader<TS;>;

--- a/etc/eea/java/util/function/Function.eea
+++ b/etc/eea/java/util/function/Function.eea
@@ -1,0 +1,4 @@
+class java/util/function/Function
+identity
+ <T:Ljava/lang/Object;>()Ljava/util/function/Function<TT;TT;>;
+ <T:Ljava/lang/Object;>()L1java/util/function/Function<TT;TT;>;

--- a/opt/jstachio-spring-webmvc/src/main/java/io/jstach/opt/spring/webmvc/JStachioModelView.java
+++ b/opt/jstachio-spring-webmvc/src/main/java/io/jstach/opt/spring/webmvc/JStachioModelView.java
@@ -13,6 +13,8 @@ import io.jstach.jstache.JStache;
 import io.jstach.jstache.JStacheInterfaces;
 import io.jstach.jstachio.JStachio;
 import io.jstach.jstachio.Output.CloseableEncodedOutput;
+import io.jstach.jstachio.context.ContextJStachio;
+import io.jstach.jstachio.context.ContextNode;
 import io.jstach.opt.spring.web.JStachioHttpMessageConverter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -60,8 +62,16 @@ public interface JStachioModelView extends View {
 			charset = StandardCharsets.UTF_8;
 		}
 		try (var o = createOutput(charset, response)) {
-			jstachio().write(model(), o);
+			var context = createContext(model, request, response);
+			jstachio().write(model(), context, o);
 		}
+	}
+
+	/*
+	 * If you want this public file an issue.
+	 */
+	private ContextNode createContext(Map<String, ?> model, HttpServletRequest request, HttpServletResponse response) {
+		return ContextNode.of(model::get);
 	}
 
 	/**
@@ -80,8 +90,8 @@ public interface JStachioModelView extends View {
 	 * @return stachio singleton by default.
 	 * @see JStachio#setStatic(java.util.function.Supplier)
 	 */
-	default JStachio jstachio() {
-		return JStachio.of();
+	default ContextJStachio jstachio() {
+		return ContextJStachio.of(JStachio.of());
 	}
 
 	/**

--- a/opt/jstachio-spring-webmvc/src/main/java/io/jstach/opt/spring/webmvc/ViewSetupHandlerInterceptor.java
+++ b/opt/jstachio-spring-webmvc/src/main/java/io/jstach/opt/spring/webmvc/ViewSetupHandlerInterceptor.java
@@ -4,9 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
-import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;

--- a/opt/jstachio-spring/src/main/java/io/jstach/opt/spring/SpringJStacheConfig.java
+++ b/opt/jstachio-spring/src/main/java/io/jstach/opt/spring/SpringJStacheConfig.java
@@ -2,6 +2,8 @@ package io.jstach.opt.spring;
 
 import io.jstach.jstache.JStache;
 import io.jstach.jstache.JStacheConfig;
+import io.jstach.jstache.JStacheFlags;
+import io.jstach.jstache.JStacheFlags.Flag;
 import io.jstach.jstache.JStachePath;
 
 /**
@@ -24,6 +26,7 @@ import io.jstach.jstache.JStachePath;
  * without it
  */
 @JStacheConfig(pathing = @JStachePath(prefix = "templates/", suffix = ".mustache"))
+@JStacheFlags(flags = Flag.CONTEXT_SUPPORT)
 public enum SpringJStacheConfig {
 
 }

--- a/spec/spec-generator/src/main/java/io/jstach/spec/generator/SpecModel.java
+++ b/spec/spec-generator/src/main/java/io/jstach/spec/generator/SpecModel.java
@@ -3,15 +3,17 @@ package io.jstach.spec.generator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import io.jstach.jstachio.context.ContextNode;
+import org.eclipse.jdt.annotation.Nullable;
 
-public class SpecModel implements ContextNode {
+import io.jstach.jstachio.context.ObjectContext;
+
+public class SpecModel extends ObjectContext {
 
 	private final Map<String, Object> object = new LinkedHashMap<>();
 
 	@Override
-	public Map<String, Object> object() {
-		return object;
+	public @Nullable Object getValue(String key) {
+		return object.get(key);
 	}
 
 	@Override
@@ -20,7 +22,7 @@ public class SpecModel implements ContextNode {
 	}
 
 	public void putAll(Map<? extends String, ? extends Object> m) {
-		object().putAll(m);
+		object.putAll(m);
 	}
 
 }

--- a/test/examples/src/main/java/io/jstach/examples/ContextAwareExample.java
+++ b/test/examples/src/main/java/io/jstach/examples/ContextAwareExample.java
@@ -3,6 +3,8 @@ package io.jstach.examples;
 import java.util.Optional;
 
 import io.jstach.jstache.JStache;
+import io.jstach.jstache.JStacheFlags;
+import io.jstach.jstache.JStacheFlags.Flag;
 import io.jstach.jstache.JStacheLambda;
 import io.jstach.jstachio.context.ContextNode;
 
@@ -19,6 +21,7 @@ import io.jstach.jstachio.context.ContextNode;
 		{{/myLambda}}
 		{{/@context}}
 		""")
+@JStacheFlags(flags = Flag.CONTEXT_SUPPORT)
 record ContextAwareExample(String message, IdContainer id) {
 
 	@JStacheLambda

--- a/test/examples/src/main/java/io/jstach/examples/ContextAwareExample.java
+++ b/test/examples/src/main/java/io/jstach/examples/ContextAwareExample.java
@@ -1,6 +1,10 @@
 package io.jstach.examples;
 
+import java.util.Optional;
+
 import io.jstach.jstache.JStache;
+import io.jstach.jstache.JStacheLambda;
+import io.jstach.jstachio.context.ContextNode;
 
 @JStache(template = """
 		{{@context.csrf}}
@@ -8,7 +12,19 @@ import io.jstach.jstache.JStache;
 		{{.}}
 		{{/@context.user}}
 		{{message}}
+		{{id.id}}
+		{{#@context}}
+		{{#myLambda}}
+		{{.}}
+		{{/myLambda}}
+		{{/@context}}
 		""")
-public record ContextAwareExample(String message) {
+record ContextAwareExample(String message, IdContainer id) {
 
+	@JStacheLambda
+	public String myLambda(ContextNode node) {
+		var csrf = Optional.ofNullable(node.get("csrf")).map(n -> n.object()).map(o -> o.toString())
+				.orElse("MISSING CSRF");
+		return "From myLambda " + csrf;
+	}
 }

--- a/test/examples/src/main/java/io/jstach/examples/ContextAwareExample.java
+++ b/test/examples/src/main/java/io/jstach/examples/ContextAwareExample.java
@@ -1,0 +1,14 @@
+package io.jstach.examples;
+
+import io.jstach.jstache.JStache;
+
+@JStache(template = """
+		{{@context.csrf}}
+		{{#@context.user}}
+		{{.}}
+		{{/@context.user}}
+		{{message}}
+		""")
+public record ContextAwareExample(String message) {
+
+}

--- a/test/examples/src/main/java/io/jstach/examples/ExampleMapNode.java
+++ b/test/examples/src/main/java/io/jstach/examples/ExampleMapNode.java
@@ -3,17 +3,19 @@ package io.jstach.examples;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.Nullable;
+
 import io.jstach.jstache.JStache;
-import io.jstach.jstachio.context.ContextNode;
+import io.jstach.jstachio.context.ObjectContext;
 
 @JStache(path = "example-map-node.mustache")
-class ExampleMapNode implements ContextNode {
+class ExampleMapNode extends ObjectContext {
 
 	private final Map<String, Object> object = new LinkedHashMap<>();
 
 	@Override
-	public Object object() {
-		return object;
+	public @Nullable Object getValue(String key) {
+		return object.get(key);
 	}
 
 }

--- a/test/examples/src/main/java/io/jstach/examples/IdContainer.java
+++ b/test/examples/src/main/java/io/jstach/examples/IdContainer.java
@@ -4,6 +4,10 @@ import java.util.UUID;
 
 class IdContainer implements Mixin {
 
+	public static IdContainer test() {
+		return new IdContainer(UUID.nameUUIDFromBytes("test".getBytes()));
+	}
+
 	private final UUID id;
 
 	public IdContainer(UUID id) {

--- a/test/examples/src/test/java/io/jstach/examples/ContextAwareTest.java
+++ b/test/examples/src/test/java/io/jstach/examples/ContextAwareTest.java
@@ -41,7 +41,6 @@ public class ContextAwareTest {
 
 				Hello
 				098f6bcd-4621-3373-8ade-4e832627b4f6
-				From myLambda MISSING CSRF
 				""";
 		assertEquals(expected, actual);
 	}

--- a/test/examples/src/test/java/io/jstach/examples/ContextAwareTest.java
+++ b/test/examples/src/test/java/io/jstach/examples/ContextAwareTest.java
@@ -1,0 +1,63 @@
+package io.jstach.examples;
+
+import static org.junit.Assert.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import io.jstach.jstachio.JStachio;
+import io.jstach.jstachio.Output;
+import io.jstach.jstachio.context.ContextNode;
+import io.jstach.jstachio.output.ContextAwareOutput;
+
+public class ContextAwareTest {
+
+	@Test
+	public void testContextAwareOutput() throws Exception {
+		var output = Output.of(new StringBuilder());
+		Map<String, String> attributes = new LinkedHashMap<>();
+		attributes.put("csrf", "TOKEN");
+		var context = ContextNode.of(attributes::get);
+		var contextOutput = ContextAwareOutput.of(output, context);
+		var model = new ContextAwareExample("Hello");
+		String actual = JStachio.of().execute(model, contextOutput).getOutput().toString();
+		String expected = """
+				TOKEN
+				Hello
+				""";
+		assertEquals(expected, actual);
+	}
+
+	@Ignore // TODO need to fix
+	@Test
+	public void testContextAwareOutputNonNull() throws Exception {
+		var output = Output.of(new StringBuilder());
+		Map<String, String> attributes = new LinkedHashMap<>();
+		attributes.put("csrf", "TOKEN");
+		var context = ContextNode.ofNonNull(attributes::get);
+		var contextOutput = ContextAwareOutput.of(output, context);
+		var model = new ContextAwareExample("Hello");
+		String actual = JStachio.of().execute(model, contextOutput).getOutput().toString();
+		String expected = """
+				TOKEN
+				Hello
+				""";
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testContextAwareMissing() throws Exception {
+		var output = Output.of(new StringBuilder());
+		var model = new ContextAwareExample("Hello");
+		String actual = JStachio.of().execute(model, output).toString();
+		String expected = """
+
+				Hello
+				""";
+		assertEquals(expected, actual);
+	}
+
+}

--- a/test/examples/src/test/java/io/jstach/examples/ContextAwareTest.java
+++ b/test/examples/src/test/java/io/jstach/examples/ContextAwareTest.java
@@ -9,20 +9,19 @@ import org.junit.Test;
 
 import io.jstach.jstachio.JStachio;
 import io.jstach.jstachio.Output;
+import io.jstach.jstachio.context.ContextJStachio;
 import io.jstach.jstachio.context.ContextNode;
-import io.jstach.jstachio.output.ContextAwareOutput;
 
 public class ContextAwareTest {
 
 	@Test
 	public void testContextAwareOutput() throws Exception {
-		var output = Output.of(new StringBuilder());
 		Map<String, String> attributes = new LinkedHashMap<>();
 		attributes.put("csrf", "TOKEN");
 		var context = ContextNode.of(attributes::get);
-		var contextOutput = ContextAwareOutput.of(output, context);
 		var model = new ContextAwareExample("Hello", IdContainer.test());
-		String actual = JStachio.of().execute(model, contextOutput).getOutput().toString();
+		var jstachio = ContextJStachio.of(JStachio.of());
+		String actual = jstachio.execute(model, context, Output.of(new StringBuilder())).toString();
 		String expected = """
 				TOKEN
 				Hello
@@ -34,9 +33,9 @@ public class ContextAwareTest {
 
 	@Test
 	public void testContextAwareMissing() throws Exception {
-		var output = Output.of(new StringBuilder());
 		var model = new ContextAwareExample("Hello", IdContainer.test());
-		String actual = JStachio.of().execute(model, output).toString();
+		var jstachio = ContextJStachio.of(JStachio.of());
+		String actual = jstachio.execute(model, Output.of(new StringBuilder())).toString();
 		String expected = """
 
 				Hello

--- a/test/examples/src/test/java/io/jstach/examples/ContextAwareTest.java
+++ b/test/examples/src/test/java/io/jstach/examples/ContextAwareTest.java
@@ -1,11 +1,10 @@
 package io.jstach.examples;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import io.jstach.jstachio.JStachio;
@@ -22,28 +21,13 @@ public class ContextAwareTest {
 		attributes.put("csrf", "TOKEN");
 		var context = ContextNode.of(attributes::get);
 		var contextOutput = ContextAwareOutput.of(output, context);
-		var model = new ContextAwareExample("Hello");
+		var model = new ContextAwareExample("Hello", IdContainer.test());
 		String actual = JStachio.of().execute(model, contextOutput).getOutput().toString();
 		String expected = """
 				TOKEN
 				Hello
-				""";
-		assertEquals(expected, actual);
-	}
-
-	@Ignore // TODO need to fix
-	@Test
-	public void testContextAwareOutputNonNull() throws Exception {
-		var output = Output.of(new StringBuilder());
-		Map<String, String> attributes = new LinkedHashMap<>();
-		attributes.put("csrf", "TOKEN");
-		var context = ContextNode.ofNonNull(attributes::get);
-		var contextOutput = ContextAwareOutput.of(output, context);
-		var model = new ContextAwareExample("Hello");
-		String actual = JStachio.of().execute(model, contextOutput).getOutput().toString();
-		String expected = """
-				TOKEN
-				Hello
+				098f6bcd-4621-3373-8ade-4e832627b4f6
+				From myLambda TOKEN
 				""";
 		assertEquals(expected, actual);
 	}
@@ -51,11 +35,13 @@ public class ContextAwareTest {
 	@Test
 	public void testContextAwareMissing() throws Exception {
 		var output = Output.of(new StringBuilder());
-		var model = new ContextAwareExample("Hello");
+		var model = new ContextAwareExample("Hello", IdContainer.test());
 		String actual = JStachio.of().execute(model, output).toString();
 		String expected = """
 
 				Hello
+				098f6bcd-4621-3373-8ade-4e832627b4f6
+				From myLambda MISSING CSRF
 				""";
 		assertEquals(expected, actual);
 	}


### PR DESCRIPTION
@dsyer I have started some initial support on context aware.

Basically the idea is sneak the context (e.g. hashmap) into the output.

That is what ContextNode.resolve does and we generate code that calls that.

```
ContextNode _context = Context.resolve(model, output);
```

Then in the template you can access it with `@context`.


In web frameworks where you are doing the finally rendering (e.g. ViewResolver or Encoder) you can then decorate usual output with a context aware one.

ContextAwareTest sort of shows this.