### PR TITLE
Add autoconfiguration for @WebMvcTest

### DIFF
--- a/opt/jstachio-spring-boot-starter-webmvc/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc.imports
+++ b/opt/jstachio-spring-boot-starter-webmvc/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc.imports
@@ -1,0 +1,2 @@
+io.jstach.opt.spring.boot.webmvc.JStachioAutoConfiguration
+io.jstach.opt.spring.boot.webmvc.JStachioWebMvcAutoConfiguration

--- a/opt/jstachio-spring-example/pom.xml
+++ b/opt/jstachio-spring-example/pom.xml
@@ -23,6 +23,11 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/opt/jstachio-spring-example/src/test/java/io/jstach/opt/spring/example/message/MessageControllerTest.java
+++ b/opt/jstachio-spring-example/src/test/java/io/jstach/opt/spring/example/message/MessageControllerTest.java
@@ -1,0 +1,33 @@
+package io.jstach.opt.spring.example.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import io.jstach.opt.spring.webmvc.JStachioModelView;
+
+@WebMvcTest(MessageController.class)
+@Import(MessageConfiguration.class)
+public class MessageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void testShowMessage() throws Exception {
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/message")).andExpect(status().isOk()).andExpect(result -> {
+			JStachioModelView view = (JStachioModelView) result.getModelAndView().getView();
+			MessagePage message = (MessagePage) view.model();
+			assertThat(message.message).isNotNull();
+		});
+
+	}
+
+}


### PR DESCRIPTION
Without this user has to manually set up the handle interceptor in tests, while it is autconfigured in the application itself.