### PR TITLE
Address #407 issue of gradle template CWD

### DIFF
--- a/api/annotation/src/main/java/io/jstach/jstache/JStache.java
+++ b/api/annotation/src/main/java/io/jstach/jstache/JStache.java
@@ -603,21 +603,22 @@ public @interface JStache {
 	 * instead of the output (<code>javax.tools.StandardLocation#CLASS_OUTPUT</code>) if
 	 * the files cannot be found.
 	 * <p>
-	 * JStachio tries to resolve your project layout and current working directory
-	 * automatically based on variety of heuristics so that you do not need to use this
-	 * flag. JStachio may not find the correct source folder for your templates but it
-	 * usually can find the correct "<em>current working directory</em>" (which will be
-	 * called "<em>CWD</em>" for the rest of this passage).
+	 * JStachio tries to resolve your project layout and project directory (current
+	 * project being compiled if in a multi-module project) automatically based on variety
+	 * of heuristics so that you do not need to use this flag. JStachio may not find the
+	 * correct source folder for your templates but it usually can find the correct
+	 * "<em>project directory</em>" (which will be called "<em>PD</em>" for the rest of
+	 * this passage).
 	 * </p>
 	 * <strong>Multiple paths can be passed by comma separating them.</strong> The paths
 	 * are tried in order. If a path does not start with a path separator then it will be
-	 * appended to the <strong>resolved</strong> CWD otherwise it is assumed to be a fully
-	 * qualified path. <strong> NOTE the CWD may not be correct! </strong>
+	 * appended to the <strong>resolved</strong> PD otherwise it is assumed to be a fully
+	 * qualified path. <strong> NOTE the PD may not be correct! </strong>
 	 * <p>
-	 * The default location is <code>CWD/src/main/resources</code>. Again the CWD may not
-	 * be resolved correctly so the only guarantee is to give the absolute path if nothing
-	 * else is working. Please file an issue with info on your build system and IDE if you
-	 * project is mostly canonical in layout if you are experiencing issues.
+	 * The default location is <code>PD/src/main/resources</code>. Again the PD may not be
+	 * resolved correctly so the only guarantee is to give the absolute path if nothing
+	 * else is working. Please file an issue with info on your build system and IDE if
+	 * your project is mostly canonical in layout if you are experiencing issues.
 	 * </p>
 	 *
 	 * <strong>If the option is blank or empty then NO fallback will happen and

--- a/doc/src/main/javadoc/overview.html
+++ b/doc/src/main/javadoc/overview.html
@@ -613,6 +613,24 @@ compileJava {
 }
 </code></pre>
 
+<h4 id="gradle_custom_buildDirectory">Gradle with custom build directory</h4>
+
+JStachio tries to resolve where the resource directory (root templates directory) is during gradle compilation by assuming
+you are following the standard build layout. This normally works provided you do not change the build layout.
+If you do you will need to set the resources compiler flag. Assuming <code>src/main/resources</code>
+is where your templates live the following will help resolve the templates:
+
+<pre>
+<code class="language-kotlin">
+compileJava {
+    options.compilerArgs.add("-Ajstache.resourcesPath=" + file("src/main/resources").absolutePath)
+}
+</code>
+</pre>
+
+The absolute path is required because it is not possible to resolve the project directory
+absolute path in the annotation processor while Gradle is compiling.
+
 <h2 id="configuration">Configuration</h2>
 
 <h3 id="compile_config">Compile time Configuration</h3>
@@ -888,6 +906,14 @@ As a painful last resort you can use Eclipse project settings and go to:
 
 Set {@value io.jstach.jstache.JStache#RESOURCES_PATH_OPTION} to the <strong>absolute</strong>
 path of your templates.
+</p>
+<p>
+<strong>If you changed the default output in either Gradle or Maven</strong> there
+is a strong possibility you will need set {@link io.jstach.jstache.JStache#RESOURCES_PATH_OPTION} 
+to an <strong>absolute</strong> path. In Maven one can resolve this by using 
+<strong>{$project.baseDir}/src/main/resources</strong> but this is usually not a problem in Maven
+as resources can be found with the annotation processor Filer. It is however a common problem
+with Gradle incremental.
 
 See {@link io.jstach.jstache.JStache#RESOURCES_PATH_OPTION} for more information.
 


### PR DESCRIPTION
Sort of a fix for #407 

This fix will fail fast for Gradle incremental and non standard build directories by requiring absolute path bet set.

Contemplated going up the directory path looking for `build.gradle` but if you change the default output then you can add a compiler flag!